### PR TITLE
[FEAT] 응원하기 개수 확인 기능 구현

### DIFF
--- a/src/main/java/com/sports/server/game/application/GameService.java
+++ b/src/main/java/com/sports/server/game/application/GameService.java
@@ -6,9 +6,9 @@ import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameRepository;
 import com.sports.server.game.domain.GameTeam;
 import com.sports.server.game.domain.GameTeamRepository;
-import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto;
+import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,6 +41,8 @@ public class GameService {
     public List<GameTeamCheerResponseDto> getCheerCountOfGameTeams(final Long gameId) {
         Game game = findGameWithId(gameId);
         List<GameTeam> gameTeams = gameTeamRepository.findAllByGame(game);
-        return gameTeams.stream().map(GameTeamCheerResponseDto::new).toList();
+        return gameTeams.stream()
+                .map(GameTeamCheerResponseDto::new)
+                .toList();
     }
 }

--- a/src/main/java/com/sports/server/game/application/GameService.java
+++ b/src/main/java/com/sports/server/game/application/GameService.java
@@ -4,6 +4,9 @@ import com.sports.server.common.exception.ExceptionMessages;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameRepository;
+import com.sports.server.game.domain.GameTeam;
+import com.sports.server.game.domain.GameTeamRepository;
+import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto;
 import java.util.List;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GameService {
 
     private final GameRepository gameRepository;
+    private final GameTeamRepository gameTeamRepository;
 
     public GameDetailResponseDto getOneGame(final Long gameId) {
         Game game = findGameWithId(gameId);
@@ -31,5 +35,12 @@ public class GameService {
     public List<GameResponseDto> getAllGames() {
         return gameRepository.findAll().stream().map(GameResponseDto::new)
                 .toList();
+    }
+
+
+    public List<GameTeamCheerResponseDto> getCheerCountOfGameTeams(final Long gameId) {
+        Game game = findGameWithId(gameId);
+        List<GameTeam> gameTeams = gameTeamRepository.findAllByGame(game);
+        return gameTeams.stream().map(GameTeamCheerResponseDto::new).toList();
     }
 }

--- a/src/main/java/com/sports/server/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/game/domain/GameTeamRepository.java
@@ -1,9 +1,9 @@
 package com.sports.server.game.domain;
 
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.repository.Repository;
 
 public interface GameTeamRepository extends Repository<GameTeam, Long> {
 
-    Optional<GameTeam> findById(final Long id);
+    List<GameTeam> findAllByGame(final Game game);
 }

--- a/src/main/java/com/sports/server/game/dto/response/GameTeamCheerResponseDto.java
+++ b/src/main/java/com/sports/server/game/dto/response/GameTeamCheerResponseDto.java
@@ -1,0 +1,13 @@
+package com.sports.server.game.dto.response;
+
+import com.sports.server.game.domain.GameTeam;
+
+public record GameTeamCheerResponseDto(
+        Long gameTeamId,
+        int cheerCount
+) {
+    public GameTeamCheerResponseDto(final GameTeam gameTeam) {
+        this(gameTeam.getId(), gameTeam.getCheerCount());
+    }
+
+}

--- a/src/main/java/com/sports/server/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/game/presentation/GameController.java
@@ -1,6 +1,7 @@
 package com.sports.server.game.presentation;
 
 import com.sports.server.game.application.GameService;
+import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto;
 import java.util.List;
@@ -26,5 +27,12 @@ public class GameController {
     @GetMapping
     public ResponseEntity<List<GameResponseDto>> getAllGames() {
         return ResponseEntity.ok(gameService.getAllGames());
+    }
+
+    @GetMapping("/{gameId}/cheer")
+    public ResponseEntity<List<GameTeamCheerResponseDto>> getCheerCountOfGameTeams(
+            @PathVariable final Long gameId
+    ) {
+        return ResponseEntity.ok(gameService.getCheerCountOfGameTeams(gameId));
     }
 }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #44 

## 📝 구현 내용
- 경기의 아이디를 통해 경기에 참여하는 팀 전체를 찾는 메서드 repository에 추가 
- 경기의 아이디를 통해 응원 개수를 조회하는 기능 구현

## 🍀 확인해야 할 부분
- GameTeamService 를 따로 분리해야 했을까요? 분리할 정도의 사이즈가 아니라고 생각하기도 하고,, GameTeam 자체가 game 에 너무 종속적이라 어차피 경기 조회를 계속해서 해야 할 것 같아서 GameService 내부에 뒀는데 동규님의 의견은 어떠신지 궁금합니다 ! controller / service 는 Game와 GameTeam 을 분리하지 않았는데 repository 는 분리해서 어색한가 싶기도 하고,, 한편으로는 레포지토리가 entity 를 따라가니 당연한게 아닌가 싶기도 하고 그러네요! 

- 그때 이야기 나눴던 대로 dto 를 record 를 이용해봤어요! 우하하
- 단순한 궁금증인데요, record 를 사용하면 다른 클래스를 상속받지 못하는 것으로 알고 있는데 저희 화면의 특성상 dto 의 내용이 겹치는 경우가 많을 것으로 예상돼요. (ex. 경기 상세 조회에서의 경기 dto, 경기 목록 조회에서의 경기 dto) 이런 경우에는 선별해서 class 로 선언하는게 옳을까요?
