### PR TITLE
[FEAT] 리그 전체 조회 및 리그 스포츠 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured'
 
     // JPA & Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/sports/server/league/application/LeagueService.java
+++ b/src/main/java/com/sports/server/league/application/LeagueService.java
@@ -1,7 +1,9 @@
 package com.sports.server.league.application;
 
 import com.sports.server.league.domain.LeagueRepository;
+import com.sports.server.league.domain.LeagueSportRepository;
 import com.sports.server.league.dto.response.LeagueResponse;
+import com.sports.server.league.dto.response.LeagueSportResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,11 +16,19 @@ import java.util.List;
 public class LeagueService {
 
     private final LeagueRepository leagueRepository;
+    private final LeagueSportRepository leagueSportRepository;
 
     public List<LeagueResponse> findAll() {
         return leagueRepository.findAll()
                 .stream()
-                .map(league -> new LeagueResponse(league.getName()))
+                .map(LeagueResponse::new)
+                .toList();
+    }
+
+    public List<LeagueSportResponse> findSportsByLeague(Long leagueId) {
+        return leagueSportRepository.findByLeagueId(leagueId)
+                .stream()
+                .map(LeagueSportResponse::new)
                 .toList();
     }
 }

--- a/src/main/java/com/sports/server/league/application/LeagueService.java
+++ b/src/main/java/com/sports/server/league/application/LeagueService.java
@@ -1,0 +1,24 @@
+package com.sports.server.league.application;
+
+import com.sports.server.league.domain.LeagueRepository;
+import com.sports.server.league.dto.response.LeagueResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LeagueService {
+
+    private final LeagueRepository leagueRepository;
+
+    public List<LeagueResponse> findAll() {
+        return leagueRepository.findAll()
+                .stream()
+                .map(league -> new LeagueResponse(league.getName()))
+                .toList();
+    }
+}

--- a/src/main/java/com/sports/server/league/domain/League.java
+++ b/src/main/java/com/sports/server/league/domain/League.java
@@ -8,9 +8,11 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "leagues")
+@Where(clause = "is_deleted = 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class League {

--- a/src/main/java/com/sports/server/league/domain/League.java
+++ b/src/main/java/com/sports/server/league/domain/League.java
@@ -6,11 +6,13 @@ import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "leagues")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class League {
 
     @Id

--- a/src/main/java/com/sports/server/league/domain/LeagueRepository.java
+++ b/src/main/java/com/sports/server/league/domain/LeagueRepository.java
@@ -1,0 +1,12 @@
+package com.sports.server.league.domain;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface LeagueRepository extends Repository<League, Long> {
+
+    @Query("select l from League l order by l.startAt, l.endAt")
+    List<League> findAll();
+}

--- a/src/main/java/com/sports/server/league/domain/LeagueRepository.java
+++ b/src/main/java/com/sports/server/league/domain/LeagueRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface LeagueRepository extends Repository<League, Long> {
 
-    @Query("select l from League l order by l.startAt, l.endAt")
+    @Query("select l from League l order by l.startAt desc, l.endAt desc")
     List<League> findAll();
 }

--- a/src/main/java/com/sports/server/league/domain/LeagueSport.java
+++ b/src/main/java/com/sports/server/league/domain/LeagueSport.java
@@ -3,11 +3,13 @@ package com.sports.server.league.domain;
 import com.sports.server.sport.domain.Sport;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "league_sports")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class LeagueSport {
 
     @Id

--- a/src/main/java/com/sports/server/league/domain/LeagueSportRepository.java
+++ b/src/main/java/com/sports/server/league/domain/LeagueSportRepository.java
@@ -1,0 +1,12 @@
+package com.sports.server.league.domain;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface LeagueSportRepository extends Repository<LeagueSport, Long> {
+
+    @EntityGraph(attributePaths = "sport")
+    List<LeagueSport> findByLeagueId(Long leagueId);
+}

--- a/src/main/java/com/sports/server/league/dto/response/LeagueResponse.java
+++ b/src/main/java/com/sports/server/league/dto/response/LeagueResponse.java
@@ -1,0 +1,4 @@
+package com.sports.server.league.dto.response;
+
+public record LeagueResponse(String name) {
+}

--- a/src/main/java/com/sports/server/league/dto/response/LeagueResponse.java
+++ b/src/main/java/com/sports/server/league/dto/response/LeagueResponse.java
@@ -1,4 +1,9 @@
 package com.sports.server.league.dto.response;
 
+import com.sports.server.league.domain.League;
+
 public record LeagueResponse(String name) {
+    public LeagueResponse(League league) {
+        this(league.getName());
+    }
 }

--- a/src/main/java/com/sports/server/league/dto/response/LeagueSportResponse.java
+++ b/src/main/java/com/sports/server/league/dto/response/LeagueSportResponse.java
@@ -1,0 +1,7 @@
+package com.sports.server.league.dto.response;
+
+public record LeagueSportResponse(
+        Long sportId,
+        String name
+) {
+}

--- a/src/main/java/com/sports/server/league/dto/response/LeagueSportResponse.java
+++ b/src/main/java/com/sports/server/league/dto/response/LeagueSportResponse.java
@@ -1,7 +1,15 @@
 package com.sports.server.league.dto.response;
 
+import com.sports.server.league.domain.LeagueSport;
+
 public record LeagueSportResponse(
         Long sportId,
         String name
 ) {
+    public LeagueSportResponse(LeagueSport leagueSport) {
+        this(
+                leagueSport.getSport().getId(),
+                leagueSport.getSport().getName()
+        );
+    }
 }

--- a/src/main/java/com/sports/server/league/presentation/LeagueController.java
+++ b/src/main/java/com/sports/server/league/presentation/LeagueController.java
@@ -2,9 +2,11 @@ package com.sports.server.league.presentation;
 
 import com.sports.server.league.application.LeagueService;
 import com.sports.server.league.dto.response.LeagueResponse;
+import com.sports.server.league.dto.response.LeagueSportResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +22,10 @@ public class LeagueController {
     @GetMapping
     public ResponseEntity<List<LeagueResponse>> findAll() {
         return ResponseEntity.ok(leagueService.findAll());
+    }
+
+    @GetMapping("/{leagueId}/sports")
+    public ResponseEntity<List<LeagueSportResponse>> findSportsByLeague(@PathVariable Long leagueId) {
+        return ResponseEntity.ok(leagueService.findSportsByLeague(leagueId));
     }
 }

--- a/src/main/java/com/sports/server/league/presentation/LeagueController.java
+++ b/src/main/java/com/sports/server/league/presentation/LeagueController.java
@@ -1,0 +1,24 @@
+package com.sports.server.league.presentation;
+
+import com.sports.server.league.application.LeagueService;
+import com.sports.server.league.dto.response.LeagueResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/leagues")
+@RequiredArgsConstructor
+public class LeagueController {
+
+    private final LeagueService leagueService;
+
+    @GetMapping
+    public ResponseEntity<List<LeagueResponse>> findAll() {
+        return ResponseEntity.ok(leagueService.findAll());
+    }
+}

--- a/src/main/java/com/sports/server/sport/domain/Sport.java
+++ b/src/main/java/com/sports/server/sport/domain/Sport.java
@@ -7,11 +7,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "sports")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Sport {
 
     @Id

--- a/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
+++ b/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
@@ -35,7 +35,7 @@ public class LeagueAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
                         .map(LeagueResponse::name)
-                        .containsExactly("삼건물 대회", "농구대잔치", "롤 대회")
+                        .containsExactly("롤 대회", "농구대잔치", "삼건물 대회")
         );
     }
 

--- a/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
+++ b/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
@@ -1,0 +1,42 @@
+package com.sports.server.league.acceptance;
+
+import com.sports.server.support.AcceptanceTest;
+import com.sports.server.league.dto.response.LeagueResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Sql(scripts = "/league-fixture.sql")
+public class LeagueAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 모든_리그를_조회한다() {
+        // given
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/leagues")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<LeagueResponse> actual = toResponses(response, LeagueResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual)
+                        .map(LeagueResponse::name)
+                        .containsExactly("삼건물 대회", "농구대잔치", "롤 대회")
+        );
+    }
+}

--- a/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
+++ b/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
@@ -41,11 +41,14 @@ public class LeagueAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 리그의_모든_스포츠를_조회한다() {
+        // given
+        Long threeBuildingCup = 1L;
+
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .get("/leagues/1/sports")
+                .get("/leagues/{leagueId}/sports", threeBuildingCup)
                 .then().log().all()
                 .extract();
 
@@ -58,7 +61,7 @@ public class LeagueAcceptanceTest extends AcceptanceTest {
                         .containsExactly("축구"),
                 () -> assertThat(actual)
                         .map(LeagueSportResponse::sportId)
-                        .containsExactly(1L)
+                        .containsExactly(threeBuildingCup)
         );
     }
 }

--- a/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
+++ b/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.sports.server.league.acceptance;
 
+import com.sports.server.league.dto.response.LeagueSportResponse;
 import com.sports.server.support.AcceptanceTest;
 import com.sports.server.league.dto.response.LeagueResponse;
 import io.restassured.RestAssured;
@@ -35,6 +36,29 @@ public class LeagueAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(actual)
                         .map(LeagueResponse::name)
                         .containsExactly("삼건물 대회", "농구대잔치", "롤 대회")
+        );
+    }
+
+    @Test
+    void 리그의_모든_스포츠를_조회한다() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/leagues/1/sports")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<LeagueSportResponse> actual = toResponses(response, LeagueSportResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual)
+                        .map(LeagueSportResponse::name)
+                        .containsExactly("축구"),
+                () -> assertThat(actual)
+                        .map(LeagueSportResponse::sportId)
+                        .containsExactly(1L)
         );
     }
 }

--- a/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
+++ b/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 public class LeagueAcceptanceTest extends AcceptanceTest {
 
     @Test
-    void 모든_리그를_조회한다() {
+    void 삭제되지_않은_모든_리그를_조회한다() {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()

--- a/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
+++ b/src/test/java/com/sports/server/league/acceptance/LeagueAcceptanceTest.java
@@ -20,8 +20,6 @@ public class LeagueAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 모든_리그를_조회한다() {
-        // given
-
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()

--- a/src/test/java/com/sports/server/support/AcceptanceTest.java
+++ b/src/test/java/com/sports/server/support/AcceptanceTest.java
@@ -27,4 +27,10 @@ public class AcceptanceTest {
         return response.jsonPath()
                 .getList(".", dtoType);
     }
+
+    protected <T> T toResponse(ExtractableResponse<Response> response,
+                                      Class<T> dtoType) {
+        return response.jsonPath()
+                .getObject(".", dtoType);
+    }
 }

--- a/src/test/java/com/sports/server/support/AcceptanceTest.java
+++ b/src/test/java/com/sports/server/support/AcceptanceTest.java
@@ -1,0 +1,30 @@
+package com.sports.server.support;
+
+import com.sports.server.support.isolation.DatabaseIsolation;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.util.List;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DatabaseIsolation
+public class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    protected <T> List<T> toResponses(ExtractableResponse<Response> response,
+                                      Class<T> dtoType) {
+        return response.jsonPath()
+                .getList(".", dtoType);
+    }
+}

--- a/src/test/java/com/sports/server/support/isolation/DatabaseIsolation.java
+++ b/src/test/java/com/sports/server/support/isolation/DatabaseIsolation.java
@@ -1,0 +1,14 @@
+package com.sports.server.support.isolation;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DatabaseIsolationExtension.class)
+public @interface DatabaseIsolation {
+}

--- a/src/test/java/com/sports/server/support/isolation/DatabaseIsolationExtension.java
+++ b/src/test/java/com/sports/server/support/isolation/DatabaseIsolationExtension.java
@@ -1,0 +1,20 @@
+package com.sports.server.support.isolation;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+class DatabaseIsolationExtension implements AfterEachCallback {
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        DatabaseManager databaseManager = getDatabaseManager(context);
+        databaseManager.truncateTables();
+    }
+
+    private DatabaseManager getDatabaseManager(ExtensionContext context) {
+        return (DatabaseManager) SpringExtension
+                .getApplicationContext(context)
+                .getBean("databaseManager");
+    }
+}

--- a/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
+++ b/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
@@ -1,0 +1,51 @@
+package com.sports.server.support.isolation;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@Transactional
+public class DatabaseManager {
+
+    private static final String SYS_CONFIG_TABLE_NAME = "sys_config";
+
+    private final EntityManager entityManager;
+    private final List<String> tableNames;
+
+    public DatabaseManager(EntityManager entityManager) {
+        this.entityManager = entityManager;
+        this.tableNames = extractTableNames();
+    }
+
+    private List<String> extractTableNames() {
+        return entityManager.getMetamodel().getEntities().stream()
+                .filter(this::isEntity)
+                .map(this::convertCamelToSnake)
+                .toList();
+    }
+
+    private boolean isEntity(EntityType<?> entityType) {
+        return entityType.getJavaType().getAnnotation(Entity.class) != null;
+    }
+
+    private String convertCamelToSnake(EntityType<?> entityType) {
+        String regex = "([a-z])([A-Z]+)";
+        String replacement = "$1_$2";
+        return entityType.getName()
+                .replaceAll(regex, replacement)
+                .toUpperCase() + "S";
+    }
+
+    public void truncateTables() {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -9,4 +9,7 @@ VALUES (2, 1, 1, '농구대잔치', '2023-11-10 00:00:00', '2023-11-15 00:00:00'
 INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
 VALUES (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', false);
 
+INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
+VALUES (4, 1, 1, '루미큐브 대회', '2023-11-01 00:00:00', '2023-11-05 00:00:00', true);
+
 SET foreign_key_checks = 1;

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -1,5 +1,13 @@
 SET foreign_key_checks = 0;
 
+-- 스포츠
+INSERT INTO sports (id, name) VALUES (1, '축구');
+INSERT INTO sports (id, name) VALUES (2, '농구');
+INSERT INTO sports (id, name) VALUES (3, '롤');
+INSERT INTO sports (id, name) VALUES (4, '루미큐브');
+
+
+-- 리그
 INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
 VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00', false);
 
@@ -11,5 +19,11 @@ VALUES (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', fal
 
 INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
 VALUES (4, 1, 1, '루미큐브 대회', '2023-11-01 00:00:00', '2023-11-05 00:00:00', true);
+
+-- 리그의 스포츠
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 1, 1);
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 2, 2);
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 3, 3);
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 4, 4);
 
 SET foreign_key_checks = 1;

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -22,8 +22,8 @@ VALUES (4, 1, 1, '루미큐브 대회', '2023-11-01 00:00:00', '2023-11-05 00:00
 
 -- 리그의 스포츠
 INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 1, 1);
-INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 2, 2);
-INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 3, 3);
-INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 4, 4);
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (2, 2, 2);
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (3, 3, 3);
+INSERT INTO league_sports (id, league_id, sport_id) VALUES (4, 4, 4);
 
 SET foreign_key_checks = 1;

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -1,0 +1,12 @@
+SET foreign_key_checks = 0;
+
+INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
+VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00', false);
+
+INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
+VALUES (2, 1, 1, '농구대잔치', '2023-11-10 00:00:00', '2023-11-15 00:00:00', false);
+
+INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
+VALUES (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', false);
+
+SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
closed #42 
closed #43 

## 📝 구현 내용
- 리그 전체 조회 기능 구현
  - 일단 response body에 리그 이름만 보내는데 더 필요한 정보가 있을까요?
  - 정렬 조건은 시작일, 종료일 ASC로 구현했습니다.
- 리그 스포츠 조회 기능 구현
- 테스트 격리 환경 구성
  - db를 사용하는 통합테스트에서 `@DatabaseIsolation`을 붙이면 테스트가 끝나고 데이터를 초기화하는 로직을 구현해 놓았습니다.


## 🍀 확인해야 할 부분
### 테스트코드
테스트 코드도 작성했습니다! 일단 E2E 테스트만 작성했어요. 테스트 코드를 어디까지 작성하면 좋을지에 대해서도 예기해보면 좋을 것 같아요. 일단 제가 생각해 놓은 건 조회 기능에 경우에는 E2E 테스트만 작성해도 충분한 것 같아요. 데이터 변경이 일어나는 기능은 E2E, 서비스, 도메인 테스트 정도 진행하면 어떨까 생각합니다.