### PR TITLE
[FEAT] 응원하기 기능 구현

### DIFF
--- a/src/main/java/com/sports/server/game/application/GameService.java
+++ b/src/main/java/com/sports/server/game/application/GameService.java
@@ -1,7 +1,5 @@
 package com.sports.server.game.application;
 
-import com.sports.server.common.exception.ExceptionMessages;
-import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameRepository;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
@@ -17,15 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class GameService {
 
     private final GameRepository gameRepository;
+    private final GameServiceUtils gameServiceUtils;
 
     public GameDetailResponseDto getOneGame(final Long gameId) {
-        Game game = findGameWithId(gameId);
+        Game game = gameServiceUtils.findGameWithId(gameId);
         return new GameDetailResponseDto(game);
-    }
-
-    public Game findGameWithId(final Long gameId) {
-        return gameRepository.findById(gameId)
-                .orElseThrow(() -> new NotFoundException(ExceptionMessages.GAME_NOT_FOUND_EXCEPTION));
     }
 
     public List<GameResponseDto> getAllGames() {

--- a/src/main/java/com/sports/server/game/application/GameService.java
+++ b/src/main/java/com/sports/server/game/application/GameService.java
@@ -4,11 +4,8 @@ import com.sports.server.common.exception.ExceptionMessages;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameRepository;
-import com.sports.server.game.domain.GameTeam;
-import com.sports.server.game.domain.GameTeamRepository;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto;
-import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,14 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class GameService {
 
     private final GameRepository gameRepository;
-    private final GameTeamRepository gameTeamRepository;
 
     public GameDetailResponseDto getOneGame(final Long gameId) {
         Game game = findGameWithId(gameId);
         return new GameDetailResponseDto(game);
     }
 
-    private Game findGameWithId(final Long gameId) {
+    public Game findGameWithId(final Long gameId) {
         return gameRepository.findById(gameId)
                 .orElseThrow(() -> new NotFoundException(ExceptionMessages.GAME_NOT_FOUND_EXCEPTION));
     }
@@ -37,12 +33,4 @@ public class GameService {
                 .toList();
     }
 
-
-    public List<GameTeamCheerResponseDto> getCheerCountOfGameTeams(final Long gameId) {
-        Game game = findGameWithId(gameId);
-        List<GameTeam> gameTeams = gameTeamRepository.findAllByGame(game);
-        return gameTeams.stream()
-                .map(GameTeamCheerResponseDto::new)
-                .toList();
-    }
 }

--- a/src/main/java/com/sports/server/game/application/GameServiceUtils.java
+++ b/src/main/java/com/sports/server/game/application/GameServiceUtils.java
@@ -1,0 +1,23 @@
+package com.sports.server.game.application;
+
+import com.sports.server.common.exception.ExceptionMessages;
+import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.game.domain.Game;
+import com.sports.server.game.domain.GameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameServiceUtils {
+
+    private final GameRepository gameRepository;
+
+    public Game findGameWithId(final Long gameId) {
+        return gameRepository.findById(gameId)
+                .orElseThrow(() -> new NotFoundException(ExceptionMessages.GAME_NOT_FOUND_EXCEPTION));
+    }
+
+}

--- a/src/main/java/com/sports/server/game/application/GameServiceUtils.java
+++ b/src/main/java/com/sports/server/game/application/GameServiceUtils.java
@@ -4,6 +4,7 @@ import com.sports.server.common.exception.ExceptionMessages;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameRepository;
+import com.sports.server.game.exception.GameErrorMessages;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +18,7 @@ public class GameServiceUtils {
 
     public Game findGameWithId(final Long gameId) {
         return gameRepository.findById(gameId)
-                .orElseThrow(() -> new NotFoundException(ExceptionMessages.GAME_NOT_FOUND_EXCEPTION));
+                .orElseThrow(() -> new NotFoundException(GameErrorMessages.GAME_NOT_FOUND_EXCEPTION));
     }
 
 }

--- a/src/main/java/com/sports/server/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamService.java
@@ -4,6 +4,7 @@ import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameTeam;
 import com.sports.server.game.domain.GameTeamRepository;
+import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
 import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import com.sports.server.game.exception.GameExceptionMessages;
 import java.util.List;
@@ -30,5 +31,12 @@ public class GameTeamService {
     private GameTeam getGameTeamWithId(final Long gameTeamId) {
         return gameTeamRepository.findById(gameTeamId)
                 .orElseThrow(() -> new NotFoundException(GameExceptionMessages.GAME_TEAM_NOT_FOUND_EXCEPTION));
+    }
+
+    @Transactional
+    public void updateCheerCount(final Long gameId, final GameTeamCheerRequestDto cheerRequestDto) {
+        gameServiceUtils.findGameWithId(gameId);
+        getGameTeamWithId(cheerRequestDto.gameTeamId());
+        gameTeamRepository.updateCheerCount(cheerRequestDto.gameTeamId(), cheerRequestDto.cheerCount());
     }
 }

--- a/src/main/java/com/sports/server/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamService.java
@@ -1,9 +1,11 @@
 package com.sports.server.game.application;
 
+import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameTeam;
 import com.sports.server.game.domain.GameTeamRepository;
 import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
+import com.sports.server.game.exception.GameExceptionMessages;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,4 +27,8 @@ public class GameTeamService {
                 .toList();
     }
 
+    private GameTeam getGameTeamWithId(final Long gameTeamId) {
+        return gameTeamRepository.findById(gameTeamId)
+                .orElseThrow(() -> new NotFoundException(GameExceptionMessages.GAME_TEAM_NOT_FOUND_EXCEPTION));
+    }
 }

--- a/src/main/java/com/sports/server/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamService.java
@@ -1,0 +1,28 @@
+package com.sports.server.game.application;
+
+import com.sports.server.game.domain.Game;
+import com.sports.server.game.domain.GameTeam;
+import com.sports.server.game.domain.GameTeamRepository;
+import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameTeamService {
+
+    private final GameService gameService;
+    private final GameTeamRepository gameTeamRepository;
+
+    public List<GameTeamCheerResponseDto> getCheerCountOfGameTeams(final Long gameId) {
+        Game game = gameService.findGameWithId(gameId);
+        List<GameTeam> gameTeams = gameTeamRepository.findAllByGame(game);
+        return gameTeams.stream()
+                .map(GameTeamCheerResponseDto::new)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/sports/server/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamService.java
@@ -14,11 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GameTeamService {
 
-    private final GameService gameService;
     private final GameTeamRepository gameTeamRepository;
+    private final GameServiceUtils gameServiceUtils;
 
     public List<GameTeamCheerResponseDto> getCheerCountOfGameTeams(final Long gameId) {
-        Game game = gameService.findGameWithId(gameId);
+        Game game = gameServiceUtils.findGameWithId(gameId);
         List<GameTeam> gameTeams = gameTeamRepository.findAllByGame(game);
         return gameTeams.stream()
                 .map(GameTeamCheerResponseDto::new)

--- a/src/main/java/com/sports/server/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamService.java
@@ -6,7 +6,7 @@ import com.sports.server.game.domain.GameTeam;
 import com.sports.server.game.domain.GameTeamRepository;
 import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
 import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
-import com.sports.server.game.exception.GameExceptionMessages;
+import com.sports.server.game.exception.GameErrorMessages;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,7 +30,7 @@ public class GameTeamService {
 
     private GameTeam getGameTeamWithId(final Long gameTeamId) {
         return gameTeamRepository.findById(gameTeamId)
-                .orElseThrow(() -> new NotFoundException(GameExceptionMessages.GAME_TEAM_NOT_FOUND_EXCEPTION));
+                .orElseThrow(() -> new NotFoundException(GameErrorMessages.GAME_TEAM_NOT_FOUND_EXCEPTION));
     }
 
     @Transactional

--- a/src/main/java/com/sports/server/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamService.java
@@ -1,5 +1,6 @@
 package com.sports.server.game.application;
 
+import com.sports.server.common.exception.CustomException;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameTeam;
@@ -9,6 +10,7 @@ import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import com.sports.server.game.exception.GameErrorMessages;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,12 @@ public class GameTeamService {
                 .toList();
     }
 
+    private void validateGameTeam(final GameTeam gameTeam, final Game game) {
+        if (!gameTeam.getGame().equals(game)) {
+            throw new CustomException(HttpStatus.NOT_FOUND, GameErrorMessages.GAME_TEAM_NOT_PARTICIPANT_EXCEPTION);
+        }
+    }
+
     private GameTeam getGameTeamWithId(final Long gameTeamId) {
         return gameTeamRepository.findById(gameTeamId)
                 .orElseThrow(() -> new NotFoundException(GameErrorMessages.GAME_TEAM_NOT_FOUND_EXCEPTION));
@@ -35,8 +43,9 @@ public class GameTeamService {
 
     @Transactional
     public void updateCheerCount(final Long gameId, final GameTeamCheerRequestDto cheerRequestDto) {
-        gameServiceUtils.findGameWithId(gameId);
-        getGameTeamWithId(cheerRequestDto.gameTeamId());
+        Game game = gameServiceUtils.findGameWithId(gameId);
+        GameTeam gameTeam = getGameTeamWithId(cheerRequestDto.gameTeamId());
+        validateGameTeam(gameTeam, game);
         gameTeamRepository.updateCheerCount(cheerRequestDto.gameTeamId(), cheerRequestDto.cheerCount());
     }
 }

--- a/src/main/java/com/sports/server/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/game/domain/GameTeamRepository.java
@@ -1,11 +1,19 @@
 package com.sports.server.game.domain;
 
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface GameTeamRepository extends Repository<GameTeam, Long> {
 
     List<GameTeam> findAllByGame(final Game game);
 
     Optional<GameTeam> findById(final Long id);
+
+    @Modifying
+    @Query("UPDATE GameTeam t SET t.cheerCount = t.cheerCount + :cheerCount WHERE t.id = :gameTeamId")
+    void updateCheerCount(@Param("gameTeamId") Long gameTeamId, @Param("cheerCount") int cheerCount);
 }

--- a/src/main/java/com/sports/server/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/game/domain/GameTeamRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.repository.Repository;
 public interface GameTeamRepository extends Repository<GameTeam, Long> {
 
     List<GameTeam> findAllByGame(final Game game);
+
+    Optional<GameTeam> findById(final Long id);
 }

--- a/src/main/java/com/sports/server/game/dto/request/GameTeamCheerRequestDto.java
+++ b/src/main/java/com/sports/server/game/dto/request/GameTeamCheerRequestDto.java
@@ -1,0 +1,7 @@
+package com.sports.server.game.dto.request;
+
+public record GameTeamCheerRequestDto(
+        Long gameTeamId,
+        int cheerCount
+) {
+}

--- a/src/main/java/com/sports/server/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/game/exception/GameErrorMessages.java
@@ -1,6 +1,6 @@
 package com.sports.server.game.exception;
 
-public class GameExceptionMessages {
+public class GameErrorMessages {
     public static final String GAME_NOT_FOUND_EXCEPTION = "해당 경기는 존재하지 않습니다.";
     public static final String GAME_TEAM_NOT_FOUND_EXCEPTION = "해당 경기의 팀은 존재하지 않습니다.";
 }

--- a/src/main/java/com/sports/server/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/game/exception/GameErrorMessages.java
@@ -3,4 +3,5 @@ package com.sports.server.game.exception;
 public class GameErrorMessages {
     public static final String GAME_NOT_FOUND_EXCEPTION = "해당 경기는 존재하지 않습니다.";
     public static final String GAME_TEAM_NOT_FOUND_EXCEPTION = "해당 경기의 팀은 존재하지 않습니다.";
+    public static final String GAME_TEAM_NOT_PARTICIPANT_EXCEPTION = "해당 팀은 해당 게임에 속하지 않습니다.";
 }

--- a/src/main/java/com/sports/server/game/exception/GameExceptionMessages.java
+++ b/src/main/java/com/sports/server/game/exception/GameExceptionMessages.java
@@ -1,0 +1,6 @@
+package com.sports.server.game.exception;
+
+public class GameExceptionMessages {
+    public static final String GAME_NOT_FOUND_EXCEPTION = "해당 경기는 존재하지 않습니다.";
+    public static final String GAME_TEAM_NOT_FOUND_EXCEPTION = "해당 경기의 팀은 존재하지 않습니다.";
+}

--- a/src/main/java/com/sports/server/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/game/presentation/GameController.java
@@ -46,6 +46,6 @@ public class GameController {
     public ResponseEntity<List<GameTeamCheerResponseDto>> updateCheerCount(@PathVariable final Long gameId,
                                                                            @RequestBody @Valid GameTeamCheerRequestDto cheerRequestDto) {
         gameTeamService.updateCheerCount(gameId, cheerRequestDto);
-        return ResponseEntity.ok(null);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/sports/server/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/game/presentation/GameController.java
@@ -1,9 +1,10 @@
 package com.sports.server.game.presentation;
 
 import com.sports.server.game.application.GameService;
-import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
+import com.sports.server.game.application.GameTeamService;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto;
+import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GameController {
 
     private final GameService gameService;
+    private final GameTeamService gameTeamService;
 
     @GetMapping("/{gameId}")
     public ResponseEntity<GameDetailResponseDto> getOneGame(@PathVariable final Long gameId) {
@@ -33,6 +35,6 @@ public class GameController {
     public ResponseEntity<List<GameTeamCheerResponseDto>> getCheerCountOfGameTeams(
             @PathVariable final Long gameId
     ) {
-        return ResponseEntity.ok(gameService.getCheerCountOfGameTeams(gameId));
+        return ResponseEntity.ok(gameTeamService.getCheerCountOfGameTeams(gameId));
     }
 }

--- a/src/main/java/com/sports/server/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/game/presentation/GameController.java
@@ -2,14 +2,18 @@ package com.sports.server.game.presentation;
 
 import com.sports.server.game.application.GameService;
 import com.sports.server.game.application.GameTeamService;
+import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
 import com.sports.server.game.dto.response.GameDetailResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto;
 import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,5 +40,12 @@ public class GameController {
             @PathVariable final Long gameId
     ) {
         return ResponseEntity.ok(gameTeamService.getCheerCountOfGameTeams(gameId));
+    }
+
+    @PostMapping("/{gameId}/cheer")
+    public ResponseEntity<List<GameTeamCheerResponseDto>> updateCheerCount(@PathVariable final Long gameId,
+                                                                           @RequestBody @Valid GameTeamCheerRequestDto cheerRequestDto) {
+        gameTeamService.updateCheerCount(gameId, cheerRequestDto);
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/test/java/com/sports/server/game/acceptance/GameTeamAcceptanceTest.java
+++ b/src/test/java/com/sports/server/game/acceptance/GameTeamAcceptanceTest.java
@@ -1,7 +1,6 @@
 package com.sports.server.game.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
 import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
@@ -21,9 +20,10 @@ public class GameTeamAcceptanceTest extends AcceptanceTest {
     void 경기에_참여하는_팀을_응원한다() {
 
         //given
-        GameTeamCheerRequestDto cheerRequestDto = new GameTeamCheerRequestDto();
         Long gameId = 1L;
+        Long gameTeamId = 1L;
         int cheerCountBeforePost = 1;
+        GameTeamCheerRequestDto cheerRequestDto = new GameTeamCheerRequestDto(gameTeamId, 1);
 
         // when
         RestAssured.given().log().all()
@@ -42,11 +42,10 @@ public class GameTeamAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        List<GameTeamCheerResponseDto> actual = toResponses(response, GameTeamCheerResponseDto.class);
-        assertAll(
-                () -> assertThat(actual)
-                        .map(GameTeamCheerResponseDto::cheerCount)
-                        .isEqualTo(cheerCountBeforePost)
-        );
+        List<GameTeamCheerResponseDto> actual = toResponses(response, GameTeamCheerResponseDto.class).stream()
+                .filter(team -> team.gameTeamId()
+                        .equals(gameTeamId)).toList();
+        assertThat(actual.get(0).cheerCount())
+                .isEqualTo(cheerCountBeforePost + 1);
     }
 }

--- a/src/test/java/com/sports/server/game/acceptance/GameTeamAcceptanceTest.java
+++ b/src/test/java/com/sports/server/game/acceptance/GameTeamAcceptanceTest.java
@@ -1,0 +1,52 @@
+package com.sports.server.game.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
+import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql(scripts = "/game-fixture.sql")
+public class GameTeamAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 경기에_참여하는_팀을_응원한다() {
+
+        //given
+        GameTeamCheerRequestDto cheerRequestDto = new GameTeamCheerRequestDto();
+        Long gameId = 1L;
+        int cheerCountBeforePost = 1;
+
+        // when
+        RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(cheerRequestDto)
+                .post("/games/{gameId}/cheer", gameId)
+                .then().log().all()
+                .extract();
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/games/{gameId}/cheer", gameId)
+                .then().log().all()
+                .extract();
+
+        // then
+        List<GameTeamCheerResponseDto> actual = toResponses(response, GameTeamCheerResponseDto.class);
+        assertAll(
+                () -> assertThat(actual)
+                        .map(GameTeamCheerResponseDto::cheerCount)
+                        .isEqualTo(cheerCountBeforePost)
+        );
+    }
+}

--- a/src/test/java/com/sports/server/game/application/GameTeamServiceTest.java
+++ b/src/test/java/com/sports/server/game/application/GameTeamServiceTest.java
@@ -32,4 +32,19 @@ public class GameTeamServiceTest {
         });
 
     }
+
+    @Test
+    void 존재하지_않는_GameTeam에_대해서_요청을_보낼_경우_예외가_발생한다() {
+
+        //given
+        Long gameId = 1L;
+        Long gameTeamId = 10000L;
+        GameTeamCheerRequestDto cheerRequestDto = new GameTeamCheerRequestDto(gameTeamId, 1);
+
+        //when&then
+        assertThrows(CustomException.class, () -> {
+            gameTeamService.updateCheerCount(gameId, cheerRequestDto);
+        });
+
+    }
 }

--- a/src/test/java/com/sports/server/game/application/GameTeamServiceTest.java
+++ b/src/test/java/com/sports/server/game/application/GameTeamServiceTest.java
@@ -1,0 +1,35 @@
+package com.sports.server.game.application;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.sports.server.common.exception.CustomException;
+import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
+import com.sports.server.support.isolation.DatabaseIsolation;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest
+@DatabaseIsolation
+@Sql(scripts = "/game-fixture.sql")
+public class GameTeamServiceTest {
+
+    @Autowired
+    private GameTeamService gameTeamService;
+
+    @Test
+    void 경기에_참여하지_않는_팀을_응원하면_예외가_발생한다() {
+
+        //given
+        Long gameId = 1L;
+        Long gameTeamId = 3L;
+        GameTeamCheerRequestDto cheerRequestDto = new GameTeamCheerRequestDto(gameTeamId, 1);
+
+        //when&then
+        assertThrows(CustomException.class, () -> {
+            gameTeamService.updateCheerCount(gameId, cheerRequestDto);
+        });
+
+    }
+}

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -1,0 +1,45 @@
+SET foreign_key_checks = 0;
+
+-- 경기
+INSERT INTO games (sport_id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter,
+                   state)
+VALUES (2, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter', 'SCHEDULED');
+
+INSERT INTO games (sport_id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter,
+                   state)
+VALUES (3, 2, 1, '롤 챔피언스', '2023-11-13T14:30:00', 'def456', '2023-11-13T15:00:00', '2nd Quarter', 'SCHEDULED');
+
+INSERT INTO games (sport_id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter,
+                   state)
+VALUES (4, 3, 2, '루미큐브 대회', '2023-11-14T18:45:00', 'ghi789', '2023-11-14T19:00:00', '3rd Quarter', 'SCHEDULED');
+
+-- 팀
+INSERT INTO teams (name, logo_image_url, administrator_id, organization_id, league_id)
+VALUES ('팀 A', 'http://example.com/logo_a.png', 1, 1, 1);
+
+INSERT INTO teams (name, logo_image_url, administrator_id, organization_id, league_id)
+VALUES ('팀 B', 'http://example.com/logo_b.png', 2, 1, 1);
+
+INSERT INTO teams (name, logo_image_url, administrator_id, organization_id, league_id)
+VALUES ('팀 C', 'http://example.com/logo_c.png', 3, 2, 2);
+
+-- 경기의 팀
+-- 농구 대전 (game_id = 1)
+INSERT INTO game_teams (game_id, team_id, cheer_count, score)
+VALUES (1, 1, 1, 0), -- 팀 A의 정보
+       (1, 2, 1, 0);
+-- 팀 B의 정보
+
+-- 롤 챔피언스 (game_id = 2)
+INSERT INTO game_teams (game_id, team_id, cheer_count, score)
+VALUES (2, 2, 1, 0),
+       (2, 3, 1, 0);
+-- 팀 C의 정보
+
+-- 루미큐브 대회 (game_id = 3)
+INSERT INTO game_teams (game_id, team_id, cheer_count, score)
+VALUES (3, 1, 1, 0),
+       (3, 3, 1, 0);
+
+
+

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -41,5 +41,4 @@ INSERT INTO game_teams (game_id, team_id, cheer_count, score)
 VALUES (3, 1, 1, 0),
        (3, 3, 1, 0);
 
-
-
+SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #47 

## 📝 구현 내용
- 두개 이상의 도메인에서 호출하는 Game 을 찾는 메서드를 GameServiceUtils 로 분리
- 응원 요청을 받고 횟수를 증가시키는 기능 구현
- 경기 횟수 증가 확인 테스트 구현

## 🍀 확인해야 할 부분
- GameController 에서 GameTeamController 를 분리하지 않은 이유
제 생각에는 Game이 무조건 GameTeam 의 진입점이기에 외부로 향하는 프레젠테이션 계층인 controller 의 경우에는 gameId 를 필수적으로 통해서만 gameTeam 로직으로 이동할 수 있어서 굳이 분리시키지 않았습니다. 이에 대한 의견이 궁금해요!
- GameService 와 GameTeamService 를 분리한 이유
진입점이 Game 으로 고정된 것은 엔드포인트 상으로 진입할 때만 gameId 가 필요한 것이고, game 을 조회한 이후에 해당 경기에 속하는 team 과 관련된 로직을 gameService 에 두게 되는 것은 너무 클래스가 커질 것으로 우려했습니다. 또한, 경기의 팀과 관련된 로직이 계속해서 증가할 것을 예상했습니다. 이에 대해서도 의견 주세요!
- 테스트 코드 관련
   - 처음으로 테스트를 작성하는 거라 이상할 수도 있는데 편하게 의견 주시면 고쳐보겠습니답 ! 🫡
- @Modifying 관련
   - 응원 횟수 증가 쿼리 이후 영속성 컨텍스트를 초기화해야 할까요? 어차피 업데이트한 이후에는 쿼리가 다시 나가니까 상관없을 것이라고 생각했는데 제가 잘못 생각했으면 알려주세요!