### PR TITLE
[FEAT] 신고 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // JPA & Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'mysql:mysql-connector-java:8.0.32'

--- a/src/main/java/com/sports/server/comment/domain/CommentRepository.java
+++ b/src/main/java/com/sports/server/comment/domain/CommentRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends Repository<Comment, Long> {
     void save(Comment comment);
@@ -15,4 +16,6 @@ public interface CommentRepository extends Repository<Comment, Long> {
             "where gt.game.id = :gameId " +
             "order by c.createdAt desc")
     List<Comment> getAllByGameOrderByCreatedAtDesc(@Param("gameId") final Long gameId);
+
+    Optional<Comment> findById(Long id);
 }

--- a/src/main/java/com/sports/server/common/domain/BaseEntity.java
+++ b/src/main/java/com/sports/server/common/domain/BaseEntity.java
@@ -1,0 +1,17 @@
+package com.sports.server.common.domain;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.domain.AbstractAggregateRoot;
+
+@MappedSuperclass
+@Getter
+public class BaseEntity<T extends AbstractAggregateRoot<T>> extends AbstractAggregateRoot<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/sports/server/report/application/ReportFactory.java
+++ b/src/main/java/com/sports/server/report/application/ReportFactory.java
@@ -1,0 +1,33 @@
+package com.sports.server.report.application;
+
+import com.sports.server.comment.domain.Comment;
+import com.sports.server.comment.domain.CommentRepository;
+import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.report.domain.Report;
+import com.sports.server.report.domain.ReportRepository;
+import com.sports.server.report.dto.request.ReportRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportFactory {
+
+    private static final String NOT_FOUND_COMMENT = "존재하지 않는 댓글입니다.";
+
+    private final ReportRepository reportRepository;
+    private final CommentRepository commentRepository;
+
+    public Report create(ReportRequest request) {
+        Comment comment = getCommentById(request.commentId());
+        return reportRepository.findByComment(comment)
+                .orElse(new Report(comment));
+    }
+
+    private Comment getCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_COMMENT));
+    }
+}

--- a/src/main/java/com/sports/server/report/application/ReportService.java
+++ b/src/main/java/com/sports/server/report/application/ReportService.java
@@ -1,0 +1,26 @@
+package com.sports.server.report.application;
+
+import com.sports.server.comment.domain.Comment;
+import com.sports.server.comment.domain.CommentRepository;
+import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.report.domain.Report;
+import com.sports.server.report.domain.ReportRepository;
+import com.sports.server.report.dto.request.ReportRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final CommentRepository commentRepository;
+
+    public void report(final ReportRequest request) {
+        Comment comment = commentRepository.findById(request.commentId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+        reportRepository.save(new Report(comment));
+    }
+}

--- a/src/main/java/com/sports/server/report/application/ReportService.java
+++ b/src/main/java/com/sports/server/report/application/ReportService.java
@@ -15,12 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReportService {
 
+    public static final String NOT_FOUND_COMMENT = "존재하지 않는 댓글입니다.";
     private final ReportRepository reportRepository;
     private final CommentRepository commentRepository;
 
     public void report(final ReportRequest request) {
-        Comment comment = commentRepository.findById(request.commentId())
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+        Comment comment = getCommentById(request.commentId());
         reportRepository.save(new Report(comment));
+    }
+
+    private Comment getCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_COMMENT));
     }
 }

--- a/src/main/java/com/sports/server/report/application/ReportService.java
+++ b/src/main/java/com/sports/server/report/application/ReportService.java
@@ -1,8 +1,5 @@
 package com.sports.server.report.application;
 
-import com.sports.server.comment.domain.Comment;
-import com.sports.server.comment.domain.CommentRepository;
-import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.report.domain.Report;
 import com.sports.server.report.domain.ReportRepository;
 import com.sports.server.report.dto.request.ReportRequest;
@@ -15,17 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReportService {
 
-    public static final String NOT_FOUND_COMMENT = "존재하지 않는 댓글입니다.";
     private final ReportRepository reportRepository;
-    private final CommentRepository commentRepository;
+    private final ReportFactory reportFactory;
 
     public void report(final ReportRequest request) {
-        Comment comment = getCommentById(request.commentId());
-        reportRepository.save(new Report(comment));
-    }
-
-    private Comment getCommentById(Long commentId) {
-        return commentRepository.findById(commentId)
-                .orElseThrow(() -> new NotFoundException(NOT_FOUND_COMMENT));
+        Report report = reportFactory.create(request);
+        reportRepository.save(report);
     }
 }

--- a/src/main/java/com/sports/server/report/domain/Report.java
+++ b/src/main/java/com/sports/server/report/domain/Report.java
@@ -1,26 +1,20 @@
 package com.sports.server.report.domain;
 
 import com.sports.server.comment.domain.Comment;
+import com.sports.server.common.domain.BaseEntity;
 import com.sports.server.common.exception.CustomException;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "reports")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Report {
+public class Report extends BaseEntity<Report> {
 
     private static final String INVALID_REPORT_BLOCKED_COMMENT = "이미 블락된 댓글은 신고할 수 없습니다.";
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", unique = true)
@@ -33,16 +27,25 @@ public class Report {
     @Enumerated(EnumType.STRING)
     private ReportState state;
 
+    protected Report() {
+        registerEvent(new ReportEvent(this));
+    }
+
     public Report(Comment comment) {
         validateBlockedComment(comment);
         this.comment = comment;
         this.reportedAt = LocalDateTime.now();
         this.state = ReportState.UNCHECKED;
+        registerEvent(new ReportEvent(this));
     }
 
     private void validateBlockedComment(Comment comment) {
         if (comment.isBlocked()) {
             throw new CustomException(HttpStatus.BAD_REQUEST, INVALID_REPORT_BLOCKED_COMMENT);
         }
+    }
+
+    public boolean isUnchecked() {
+        return this.state == ReportState.UNCHECKED;
     }
 }

--- a/src/main/java/com/sports/server/report/domain/Report.java
+++ b/src/main/java/com/sports/server/report/domain/Report.java
@@ -26,4 +26,10 @@ public class Report {
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
     private ReportState state;
+
+    public Report(Comment comment) {
+        this.comment = comment;
+        this.reportedAt = LocalDateTime.now();
+        this.state = ReportState.UNCHECKED;
+    }
 }

--- a/src/main/java/com/sports/server/report/domain/Report.java
+++ b/src/main/java/com/sports/server/report/domain/Report.java
@@ -1,16 +1,20 @@
 package com.sports.server.report.domain;
 
 import com.sports.server.comment.domain.Comment;
+import com.sports.server.common.exception.CustomException;
 import jakarta.persistence.*;
-
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "reports")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report {
+
+    private static final String INVALID_REPORT_BLOCKED_COMMENT = "이미 블락된 댓글은 신고할 수 없습니다.";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,8 +32,15 @@ public class Report {
     private ReportState state;
 
     public Report(Comment comment) {
+        validateBlockedComment(comment);
         this.comment = comment;
         this.reportedAt = LocalDateTime.now();
         this.state = ReportState.UNCHECKED;
+    }
+
+    private void validateBlockedComment(Comment comment) {
+        if (comment.isBlocked()) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, INVALID_REPORT_BLOCKED_COMMENT);
+        }
     }
 }

--- a/src/main/java/com/sports/server/report/domain/Report.java
+++ b/src/main/java/com/sports/server/report/domain/Report.java
@@ -4,6 +4,7 @@ import com.sports.server.comment.domain.Comment;
 import com.sports.server.common.exception.CustomException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "reports")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Report {
 
     private static final String INVALID_REPORT_BLOCKED_COMMENT = "이미 블락된 댓글은 신고할 수 없습니다.";

--- a/src/main/java/com/sports/server/report/domain/ReportEvent.java
+++ b/src/main/java/com/sports/server/report/domain/ReportEvent.java
@@ -1,0 +1,4 @@
+package com.sports.server.report.domain;
+
+public record ReportEvent(Report report) {
+}

--- a/src/main/java/com/sports/server/report/domain/ReportRepository.java
+++ b/src/main/java/com/sports/server/report/domain/ReportRepository.java
@@ -1,8 +1,13 @@
 package com.sports.server.report.domain;
 
+import com.sports.server.comment.domain.Comment;
 import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
 
 public interface ReportRepository extends Repository<Report, Long> {
 
     void save(Report report);
+
+    Optional<Report> findByComment(Comment comment);
 }

--- a/src/main/java/com/sports/server/report/domain/ReportRepository.java
+++ b/src/main/java/com/sports/server/report/domain/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.sports.server.report.domain;
+
+import org.springframework.data.repository.Repository;
+
+public interface ReportRepository extends Repository<Report, Long> {
+
+    void save(Report report);
+}

--- a/src/main/java/com/sports/server/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/sports/server/report/dto/request/ReportRequest.java
@@ -1,0 +1,4 @@
+package com.sports.server.report.dto.request;
+
+public record ReportRequest(Long commentId) {
+}

--- a/src/main/java/com/sports/server/report/infrastructure/ReportCheckClient.java
+++ b/src/main/java/com/sports/server/report/infrastructure/ReportCheckClient.java
@@ -1,0 +1,11 @@
+package com.sports.server.report.infrastructure;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface ReportCheckClient {
+
+    @PostExchange("/deploy")
+    ResponseEntity<Void> check(@RequestBody ReportCheckRequest request);
+}

--- a/src/main/java/com/sports/server/report/infrastructure/ReportCheckRequest.java
+++ b/src/main/java/com/sports/server/report/infrastructure/ReportCheckRequest.java
@@ -1,0 +1,8 @@
+package com.sports.server.report.infrastructure;
+
+public record ReportCheckRequest(
+        String target,
+        Long commentId,
+        Long reportId
+) {
+}

--- a/src/main/java/com/sports/server/report/infrastructure/ReportClientConfig.java
+++ b/src/main/java/com/sports/server/report/infrastructure/ReportClientConfig.java
@@ -1,0 +1,26 @@
+package com.sports.server.report.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class ReportClientConfig {
+
+    @Value("${report-check-origin}")
+    private String reportCheckOrigin;
+
+    @Bean
+    public ReportCheckClient grammarClient() {
+        WebClient client = WebClient.builder()
+                .baseUrl(reportCheckOrigin)
+                .build();
+        return HttpServiceProxyFactory
+                .builder(WebClientAdapter.forClient(client))
+                .build()
+                .createClient(ReportCheckClient.class);
+    }
+}

--- a/src/main/java/com/sports/server/report/infrastructure/ReportEventHandler.java
+++ b/src/main/java/com/sports/server/report/infrastructure/ReportEventHandler.java
@@ -1,0 +1,45 @@
+package com.sports.server.report.infrastructure;
+
+import com.sports.server.comment.domain.Comment;
+import com.sports.server.common.exception.CustomException;
+import com.sports.server.report.domain.Report;
+import com.sports.server.report.domain.ReportEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ReportEventHandler {
+
+    private static final String REPORT_CHECK_SERVER_ERROR = "신고 검사 서버에 문제가 발생했습니다";
+
+    private final ReportCheckClient reportCheckClient;
+
+    @TransactionalEventListener
+    @Async
+    public void handle(ReportEvent event) {
+        Report report = event.report();
+        if (report.isUnchecked()) {
+            checkReport(report);
+        }
+    }
+
+    private void checkReport(Report report) {
+        Comment comment = report.getComment();
+        ReportCheckRequest request = new ReportCheckRequest(
+                comment.getContent(), comment.getId(), report.getId()
+        );
+        ResponseEntity<Void> response = reportCheckClient.check(request);
+        validateResponse(response);
+    }
+
+    private void validateResponse(ResponseEntity<Void> response) {
+        if (response.getStatusCode().is5xxServerError()) {
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, REPORT_CHECK_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/sports/server/report/presentation/ReportController.java
+++ b/src/main/java/com/sports/server/report/presentation/ReportController.java
@@ -1,0 +1,26 @@
+package com.sports.server.report.presentation;
+
+
+import com.sports.server.report.application.ReportService;
+import com.sports.server.report.dto.request.ReportRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<Void> report(@RequestBody ReportRequest request) {
+        reportService.report(request);
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,3 +10,5 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+
+report-check-origin: fake-origin.com

--- a/src/test/java/com/sports/server/report/ReportFixtureRepository.java
+++ b/src/test/java/com/sports/server/report/ReportFixtureRepository.java
@@ -1,0 +1,10 @@
+package com.sports.server.report;
+
+import com.sports.server.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportFixtureRepository extends JpaRepository<Report, Long> {
+    Optional<Report> findByCommentId(Long commentId);
+}

--- a/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
@@ -27,13 +27,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ReportRequest request = new ReportRequest(existComment);
 
             // when
-            ExtractableResponse<Response> response = RestAssured.given().log().all()
-                    .when()
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(request)
-                    .post("/reports")
-                    .then().log().all()
-                    .extract();
+            ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -46,13 +40,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ReportRequest request = new ReportRequest(notExistComment);
 
             // when
-            ExtractableResponse<Response> response = RestAssured.given().log().all()
-                    .when()
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(request)
-                    .post("/reports")
-                    .then().log().all()
-                    .extract();
+            ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
@@ -65,16 +53,34 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ReportRequest request = new ReportRequest(blockedComment);
 
             // when
-            ExtractableResponse<Response> response = RestAssured.given().log().all()
-                    .when()
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(request)
-                    .post("/reports")
-                    .then().log().all()
-                    .extract();
+            ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
+
+        @Test
+        void 이미_신고된_댓글을_또_신고_가능하다() {
+            // given
+            Long existComment = 1L;
+            ReportRequest request = new ReportRequest(existComment);
+            댓글을_신고한다(request);
+
+            // when
+            ExtractableResponse<Response> response = 댓글을_신고한다(request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        }
+    }
+
+    private static ExtractableResponse<Response> 댓글을_신고한다(ReportRequest request) {
+        return RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/reports")
+                .then().log().all()
+                .extract();
     }
 }

--- a/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
@@ -5,6 +5,8 @@ import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,24 +15,47 @@ import org.springframework.test.context.jdbc.Sql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql(scripts = "/report-fixture.sql")
-public class ReportAcceptanceTest extends AcceptanceTest {
+class ReportAcceptanceTest extends AcceptanceTest {
 
-    @Test
-    void 댓글을_신고한다() {
-        // given
-        Long commentId = 1L;
-        ReportRequest request = new ReportRequest(commentId);
+    @DisplayName("신고를 할 때")
+    @Nested
+    class ReportTest {
+        @Test
+        void 존재하는_댓글이면_신고한다() {
+            // given
+            Long existComment = 1L;
+            ReportRequest request = new ReportRequest(existComment);
 
-        // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(request)
-                .post("/reports")
-                .then().log().all()
-                .extract();
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .post("/reports")
+                    .then().log().all()
+                    .extract();
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        void 존재하지_않는_댓글이면_404를_응답한다() {
+            // given
+            Long notExistComment = 100L;
+            ReportRequest request = new ReportRequest(notExistComment);
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .post("/reports")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
     }
 }

--- a/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
@@ -57,5 +57,24 @@ class ReportAcceptanceTest extends AcceptanceTest {
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
         }
+
+        @Test
+        void 이미_블락된_댓글이면_400을_응답한다() {
+            // given
+            Long blockedComment = 2L;
+            ReportRequest request = new ReportRequest(blockedComment);
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .post("/reports")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
     }
 }

--- a/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
@@ -1,0 +1,36 @@
+package com.sports.server.report.acceptance;
+
+import com.sports.server.report.dto.request.ReportRequest;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql(scripts = "/report-fixture.sql")
+public class ReportAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 댓글을_신고한다() {
+        // given
+        Long commentId = 1L;
+        ReportRequest request = new ReportRequest(commentId);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/reports")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/report/acceptance/ReportAcceptanceTest.java
@@ -13,6 +13,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @Sql(scripts = "/report-fixture.sql")
 class ReportAcceptanceTest extends AcceptanceTest {
@@ -30,7 +35,10 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                    () -> verify(reportCheckClient).check(any())
+            );
         }
 
         @Test
@@ -43,7 +51,10 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
+                    () -> verify(reportCheckClient, never()).check(any())
+            );
         }
 
         @Test
@@ -56,7 +67,10 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                    () -> verify(reportCheckClient, never()).check(any())
+            );
         }
 
         @Test
@@ -70,7 +84,10 @@ class ReportAcceptanceTest extends AcceptanceTest {
             ExtractableResponse<Response> response = 댓글을_신고한다(request);
 
             // then
-            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                    () -> verify(reportCheckClient, times(2)).check(any())
+            );
         }
     }
 

--- a/src/test/java/com/sports/server/report/application/ReportFactoryTest.java
+++ b/src/test/java/com/sports/server/report/application/ReportFactoryTest.java
@@ -2,20 +2,17 @@ package com.sports.server.report.application;
 
 import com.sports.server.report.domain.Report;
 import com.sports.server.report.dto.request.ReportRequest;
-import com.sports.server.support.isolation.DatabaseIsolation;
+import com.sports.server.support.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@DatabaseIsolation
 @Sql(scripts = "/report-fixture.sql")
-class ReportFactoryTest {
+class ReportFactoryTest extends ServiceTest {
 
     @Autowired
     private ReportFactory reportFactory;

--- a/src/test/java/com/sports/server/report/application/ReportFactoryTest.java
+++ b/src/test/java/com/sports/server/report/application/ReportFactoryTest.java
@@ -1,0 +1,53 @@
+package com.sports.server.report.application;
+
+import com.sports.server.report.domain.Report;
+import com.sports.server.report.dto.request.ReportRequest;
+import com.sports.server.support.isolation.DatabaseIsolation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DatabaseIsolation
+@Sql(scripts = "/report-fixture.sql")
+class ReportFactoryTest {
+
+    @Autowired
+    private ReportFactory reportFactory;
+
+    @DisplayName("신고를 생성할 때")
+    @Nested
+    class CreateTest {
+
+        @Test
+        void 같은_댓글의_신고가_없으면_새로_생성한다() {
+            // given
+            Long commentId = 1L;
+            ReportRequest request = new ReportRequest(commentId);
+
+            // when
+            Report report = reportFactory.create(request);
+
+            // then
+            assertThat(report.getId()).isNull();
+        }
+
+        @Test
+        void 같은_댓글의_신고가_있으면_있는걸_반환한다() {
+            // given
+            Long existReportComment = 3L;
+            ReportRequest request = new ReportRequest(existReportComment);
+
+            // when
+            Report report = reportFactory.create(request);
+
+            // then
+            assertThat(report.getId()).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/sports/server/report/application/ReportServiceTest.java
+++ b/src/test/java/com/sports/server/report/application/ReportServiceTest.java
@@ -76,13 +76,14 @@ class ReportServiceTest {
             Long commentId = 1L;
             ReportRequest request = new ReportRequest(commentId);
             reportService.report(request);
+            long beforeReport = reportFixtureRepository.count();
 
             // when
             reportService.report(request);
 
             // when
-            long reportCount = reportFixtureRepository.count();
-            assertThat(reportCount).isEqualTo(1);
+            long afterReport = reportFixtureRepository.count();
+            assertThat(afterReport).isEqualTo(beforeReport);
         }
     }
 }

--- a/src/test/java/com/sports/server/report/application/ReportServiceTest.java
+++ b/src/test/java/com/sports/server/report/application/ReportServiceTest.java
@@ -4,12 +4,11 @@ import com.sports.server.common.exception.CustomException;
 import com.sports.server.report.ReportFixtureRepository;
 import com.sports.server.report.domain.Report;
 import com.sports.server.report.dto.request.ReportRequest;
-import com.sports.server.support.isolation.DatabaseIsolation;
+import com.sports.server.support.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.Optional;
@@ -17,10 +16,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
-@DatabaseIsolation
 @Sql(scripts = "/report-fixture.sql")
-class ReportServiceTest {
+class ReportServiceTest extends ServiceTest {
 
     @Autowired
     private ReportService reportService;

--- a/src/test/java/com/sports/server/report/application/ReportServiceTest.java
+++ b/src/test/java/com/sports/server/report/application/ReportServiceTest.java
@@ -69,5 +69,20 @@ class ReportServiceTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage("이미 블락된 댓글은 신고할 수 없습니다.");
         }
+
+        @Test
+        void 같은_댓글로_신고하면_중복_저장되지_않는다() {
+            // given
+            Long commentId = 1L;
+            ReportRequest request = new ReportRequest(commentId);
+            reportService.report(request);
+
+            // when
+            reportService.report(request);
+
+            // when
+            long reportCount = reportFixtureRepository.count();
+            assertThat(reportCount).isEqualTo(1);
+        }
     }
 }

--- a/src/test/java/com/sports/server/report/application/ReportServiceTest.java
+++ b/src/test/java/com/sports/server/report/application/ReportServiceTest.java
@@ -1,0 +1,73 @@
+package com.sports.server.report.application;
+
+import com.sports.server.common.exception.CustomException;
+import com.sports.server.report.ReportFixtureRepository;
+import com.sports.server.report.domain.Report;
+import com.sports.server.report.dto.request.ReportRequest;
+import com.sports.server.support.isolation.DatabaseIsolation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@DatabaseIsolation
+@Sql(scripts = "/report-fixture.sql")
+class ReportServiceTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private ReportFixtureRepository reportFixtureRepository;
+
+    @DisplayName("신고를 저장할 때")
+    @Nested
+    class CreateReport {
+
+        @Test
+        void 블락되지_않은_댓글의_신고는_저장한다() {
+            // given
+            Long commentId = 1L;
+            ReportRequest request = new ReportRequest(commentId);
+
+            // when
+            reportService.report(request);
+
+            // then
+            Optional<Report> actual = reportFixtureRepository.findByCommentId(commentId);
+            assertThat(actual).isPresent();
+        }
+
+        @Test
+        void 존재하지_않은_댓글은_저장하지_않는다() {
+            // given
+            Long notExistComment = 100L;
+            ReportRequest request = new ReportRequest(notExistComment);
+
+            // when then
+            assertThatThrownBy(() -> reportService.report(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("존재하지 않는 댓글입니다.");
+        }
+
+        @Test
+        void 블락된_댓글은_저장하지_않는다() {
+            // given
+            Long blockedComment = 2L;
+            ReportRequest request = new ReportRequest(blockedComment);
+
+            // when then
+            assertThatThrownBy(() -> reportService.report(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("이미 블락된 댓글은 신고할 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/com/sports/server/report/domain/ReportTest.java
+++ b/src/test/java/com/sports/server/report/domain/ReportTest.java
@@ -1,0 +1,44 @@
+package com.sports.server.report.domain;
+
+import com.sports.server.comment.domain.Comment;
+import com.sports.server.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+
+class ReportTest {
+
+    @DisplayName("신고는")
+    @Nested
+    class CreateTest {
+
+        @Test
+        void 댓글로_생성한다() {
+            // given
+            Comment comment = new Comment("신고해봐", 1L);
+
+            // when
+            Report report = new Report(comment);
+
+            // then
+            assertThat(report).isNotNull();
+        }
+
+        @Test
+        void 블락된_댓글로_생성할_수_없다() {
+            // given
+            Comment comment = mock(Comment.class);
+            given(comment.isBlocked()).willReturn(true);
+
+            // when then
+            assertThatThrownBy(() -> new Report(comment))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("이미 블락된 댓글은 신고할 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/com/sports/server/report/infrastructure/ReportEventHandlerTest.java
+++ b/src/test/java/com/sports/server/report/infrastructure/ReportEventHandlerTest.java
@@ -1,0 +1,75 @@
+package com.sports.server.report.infrastructure;
+
+import com.sports.server.comment.domain.Comment;
+import com.sports.server.report.domain.Report;
+import com.sports.server.report.domain.ReportEvent;
+import com.sports.server.support.ServiceTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@Sql(scripts = "/report-fixture.sql")
+class ReportEventHandlerTest extends ServiceTest {
+
+    @Autowired
+    private ReportEventHandler reportEventHandler;
+
+    @DisplayName("신고 이벤트가 발생하면")
+    @Nested
+    class ReportEventHandleTest {
+
+        private Report report;
+
+        private static final String COMMENT_CONTENT = "신고될 댓글";
+        private static final Long COMMENT_ID = 1L;
+        private static final Long REPORT_ID = 1L;
+
+        @BeforeEach
+        void init() {
+            report = mock(Report.class);
+            Comment comment = mock(Comment.class);
+            given(report.getComment()).willReturn(comment);
+            given(comment.getContent()).willReturn(COMMENT_CONTENT);
+            given(comment.getId()).willReturn(COMMENT_ID);
+            given(report.getId()).willReturn(REPORT_ID);
+        }
+
+        @Test
+        void 아직_검사가_안된_신고는_검사를_요청한다() {
+            // given
+            given(report.isUnchecked()).willReturn(true);
+            given(reportCheckClient.check(any()))
+                    .willReturn(ResponseEntity.ok().build());
+
+            // when
+            reportEventHandler.handle(new ReportEvent(report));
+
+            // then
+            verify(reportCheckClient).check(
+                    new ReportCheckRequest(COMMENT_CONTENT, COMMENT_ID, REPORT_ID)
+            );
+        }
+
+        @Test
+        void 이미_검사된_신고는_검사를_요청하지_않는다() {
+            // given
+            given(report.isUnchecked()).willReturn(false);
+            given(reportCheckClient.check(any()))
+                    .willReturn(ResponseEntity.ok().build());
+
+            // when
+            reportEventHandler.handle(new ReportEvent(report));
+
+            // then
+            verify(reportCheckClient, never()).check(any());
+        }
+    }
+}

--- a/src/test/java/com/sports/server/support/AcceptanceTest.java
+++ b/src/test/java/com/sports/server/support/AcceptanceTest.java
@@ -9,8 +9,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DatabaseIsolation
@@ -20,11 +24,14 @@ public class AcceptanceTest {
     private int port;
 
     @MockBean
-    private ReportCheckClient reportCheckClient;
+    protected ReportCheckClient reportCheckClient;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+
+        given(reportCheckClient.check(any()))
+                .willReturn(ResponseEntity.ok().build());
     }
 
     protected <T> List<T> toResponses(ExtractableResponse<Response> response,

--- a/src/test/java/com/sports/server/support/AcceptanceTest.java
+++ b/src/test/java/com/sports/server/support/AcceptanceTest.java
@@ -1,11 +1,13 @@
 package com.sports.server.support;
 
+import com.sports.server.report.infrastructure.ReportCheckClient;
 import com.sports.server.support.isolation.DatabaseIsolation;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 import java.util.List;
@@ -16,6 +18,9 @@ public class AcceptanceTest {
 
     @LocalServerPort
     private int port;
+
+    @MockBean
+    private ReportCheckClient reportCheckClient;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/sports/server/support/ServiceTest.java
+++ b/src/test/java/com/sports/server/support/ServiceTest.java
@@ -2,13 +2,24 @@ package com.sports.server.support;
 
 import com.sports.server.report.infrastructure.ReportCheckClient;
 import com.sports.server.support.isolation.DatabaseIsolation;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
 @DatabaseIsolation
 public class ServiceTest {
 
     @MockBean
-    private ReportCheckClient reportCheckClient;
+    protected ReportCheckClient reportCheckClient;
+
+    @BeforeEach
+    void init() {
+        given(reportCheckClient.check(any()))
+                .willReturn(ResponseEntity.ok().build());
+    }
 }

--- a/src/test/java/com/sports/server/support/ServiceTest.java
+++ b/src/test/java/com/sports/server/support/ServiceTest.java
@@ -1,0 +1,14 @@
+package com.sports.server.support;
+
+import com.sports.server.report.infrastructure.ReportCheckClient;
+import com.sports.server.support.isolation.DatabaseIsolation;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+@DatabaseIsolation
+public class ServiceTest {
+
+    @MockBean
+    private ReportCheckClient reportCheckClient;
+}

--- a/src/test/resources/report-fixture.sql
+++ b/src/test/resources/report-fixture.sql
@@ -2,9 +2,16 @@ SET foreign_key_checks = 0;
 
 -- 신고할 댓글
 INSERT INTO comments (id, created_at, content, is_blocked, game_team_id)
-VALUES (1, '2023-11-11 00:00:00', '너무 못하네', false, 1);
+VALUES (1, '2023-11-11 00:00:00', '아직 신고안된 댓글이야', false, 1);
 
 INSERT INTO comments (id, created_at, content, is_blocked, game_team_id)
-VALUES (2, '2023-11-11 00:00:00', '너무 못하네', true, 1);
+VALUES (2, '2023-11-11 00:00:00', '이미 블락된 댓글이야', true, 1);
+
+INSERT INTO comments (id, created_at, content, is_blocked, game_team_id)
+VALUES (3, '2023-11-11 00:00:00', '이미 신고된 댓글이야', false, 1);
+
+-- 신고
+INSERT INTO reports (id, comment_id, reported_at, state)
+VALUES (1, 3, '2023-11-11 00:00:00', 'UNCHECKED');
 
 SET foreign_key_checks = 1;

--- a/src/test/resources/report-fixture.sql
+++ b/src/test/resources/report-fixture.sql
@@ -4,4 +4,7 @@ SET foreign_key_checks = 0;
 INSERT INTO comments (id, created_at, content, is_blocked, game_team_id)
 VALUES (1, '2023-11-11 00:00:00', '너무 못하네', false, 1);
 
+INSERT INTO comments (id, created_at, content, is_blocked, game_team_id)
+VALUES (2, '2023-11-11 00:00:00', '너무 못하네', true, 1);
+
 SET foreign_key_checks = 1;

--- a/src/test/resources/report-fixture.sql
+++ b/src/test/resources/report-fixture.sql
@@ -1,0 +1,7 @@
+SET foreign_key_checks = 0;
+
+-- 신고할 댓글
+INSERT INTO comments (id, created_at, content, is_blocked, game_team_id)
+VALUES (1, '2023-11-11 00:00:00', '너무 못하네', false, 1);
+
+SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
closed #48


## 📝 구현 내용
### 신고 기능 구현
- comment가 없는 경우
    - 404 “존재하지 않는 댓글”
- comment가 이미 block된 경우
    - 400 BAD REQUEST “이미 블락된 댓글입니다.”
- 해당 comment에 대한 report가 이미 있는 경우
    - UNCHEKCED인 경우에만 람다 다시 호출
    - 아니면 아무것도 하지 않음


## 🍀 확인해야 할 부분
### base entity 적용 제안
각 도메인 엔티티에 중복되는 코드를 추상화하는 `BaseEntity`를 각 엔티티에 적용하면 어떨까요? id를 작성하는 부분이랑 이벤트를 발행하는 코드를 넣을 수 있어요.
``` java
@MappedSuperclass
@Getter
public class BaseEntity<T extends AbstractAggregateRoot<T>> extends AbstractAggregateRoot<T> {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
}
```

### 도메인 이벤트 적용
이벤트를 사용하여 람다를 호출하는 부분을 `ReportService`나 신고 도메인 부분에서 분리했어요. 신고가 이루어진 후 람다 서버를 호출하든, 호출 방법이 변경되든 신고 도메인 부분엔 코드 변경이 없도록 하기 위함이에요. `AbstractAggregateRoot`를 사용해서 도메인 내부에서 이벤트를 발행하도록 했습니다. 궁금한거 있으면 질문해주세요!

### ServiceTest, AcceptanceTest
테스트를 진행할 때 각 Service, 각 인수 테스트에 공통적인 부분들을 모아놓은 부모 테스트 클래스들입니다. 대표적으로 필요한 이유가 람다를 호출하는 인터페이스인 `ReportCheckClient`를 테스트 시에 실제로 사용할 수 없기에 `Mock`으로 세팅해야 하는데 이 부모클래스들로 공통으로 설정해줄 수 있습니다.

++ 프로덕션 코드에서 어떤 클래스가 어떤 역할을 하는지 잘 모르겠다면 그 클래스의 테스트 클래스를 확인해주세요! 어떤 기능과 검증을 수행하는지 어느정도 파악할 수 있습니다.