### PR TITLE
[FEAT] 라인업 조회 기능 추가 및 TeamPlayer 추가

### DIFF
--- a/src/main/java/com/sports/server/game/application/GameTeamPlayerService.java
+++ b/src/main/java/com/sports/server/game/application/GameTeamPlayerService.java
@@ -1,0 +1,34 @@
+package com.sports.server.game.application;
+
+import com.sports.server.game.domain.GameTeam;
+import com.sports.server.game.domain.GameTeamPlayer;
+import com.sports.server.game.domain.GameTeamPlayerRepository;
+import com.sports.server.game.dto.response.GameLineupResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameTeamPlayerService {
+
+    private final GameTeamPlayerRepository gameTeamPlayerRepository;
+
+    public List<GameLineupResponse> getLineup(final Long gameId) {
+        Map<GameTeam, List<GameTeamPlayer>> groupByTeam = gameTeamPlayerRepository.findPlayersByGameId(gameId)
+                .stream()
+                .collect(groupingBy(GameTeamPlayer::getGameTeam));
+        return groupByTeam.keySet()
+                .stream()
+                .sorted(Comparator.comparingLong(GameTeam::getId))
+                .map(gameTeam -> new GameLineupResponse(gameTeam, groupByTeam.get(gameTeam)))
+                .toList();
+    }
+}

--- a/src/main/java/com/sports/server/game/domain/GameTeamPlayerRepository.java
+++ b/src/main/java/com/sports/server/game/domain/GameTeamPlayerRepository.java
@@ -1,0 +1,17 @@
+package com.sports.server.game.domain;
+
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface GameTeamPlayerRepository extends Repository<GameTeamPlayer, Long> {
+
+    @Query("select gtp from GameTeamPlayer gtp " +
+            "join fetch gtp.gameTeam gt " +
+            "join fetch gt.team " +
+            "where gt.game.id = :gameId")
+    List<GameTeamPlayer> findPlayersByGameId(@Param("gameId") final Long gameId);
+}

--- a/src/main/java/com/sports/server/game/dto/response/GameLineupResponse.java
+++ b/src/main/java/com/sports/server/game/dto/response/GameLineupResponse.java
@@ -1,0 +1,17 @@
+package com.sports.server.game.dto.response;
+
+import java.util.List;
+
+public record GameLineupResponse(
+        Long gameTeamId,
+        String teamName,
+        List<PlayerResponse> gameTeamPlayers
+
+) {
+
+    public record PlayerResponse(
+            String playerName,
+            String description
+    ) {
+    }
+}

--- a/src/main/java/com/sports/server/game/dto/response/GameLineupResponse.java
+++ b/src/main/java/com/sports/server/game/dto/response/GameLineupResponse.java
@@ -1,5 +1,8 @@
 package com.sports.server.game.dto.response;
 
+import com.sports.server.game.domain.GameTeam;
+import com.sports.server.game.domain.GameTeamPlayer;
+
 import java.util.List;
 
 public record GameLineupResponse(
@@ -9,9 +12,22 @@ public record GameLineupResponse(
 
 ) {
 
+    public GameLineupResponse(GameTeam gameTeam, List<GameTeamPlayer> gameTeamPlayers) {
+        this(
+          gameTeam.getId(),
+          gameTeam.getTeam().getName(),
+          gameTeamPlayers.stream()
+                  .map(PlayerResponse::new)
+                  .toList()
+        );
+    }
+
     public record PlayerResponse(
             String playerName,
             String description
     ) {
+        public PlayerResponse(GameTeamPlayer player) {
+            this(player.getName(), player.getDescription());
+        }
     }
 }

--- a/src/main/java/com/sports/server/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/game/presentation/GameController.java
@@ -1,9 +1,11 @@
 package com.sports.server.game.presentation;
 
 import com.sports.server.game.application.GameService;
+import com.sports.server.game.application.GameTeamPlayerService;
 import com.sports.server.game.application.GameTeamService;
 import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
 import com.sports.server.game.dto.response.GameDetailResponse;
+import com.sports.server.game.dto.response.GameLineupResponse;
 import com.sports.server.game.dto.response.GameResponseDto;
 import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
 import jakarta.validation.Valid;
@@ -20,6 +22,7 @@ public class GameController {
 
     private final GameService gameService;
     private final GameTeamService gameTeamService;
+    private final GameTeamPlayerService gameTeamPlayerService;
 
     @GetMapping("/{gameId}")
     public ResponseEntity<GameDetailResponse> getGameDetail(@PathVariable final Long gameId) {
@@ -43,5 +46,10 @@ public class GameController {
                                                                            @RequestBody @Valid GameTeamCheerRequestDto cheerRequestDto) {
         gameTeamService.updateCheerCount(gameId, cheerRequestDto);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{gameId}/lineup")
+    public ResponseEntity<List<GameLineupResponse>> getGameLineup(@PathVariable final Long gameId) {
+        return ResponseEntity.ok(gameTeamPlayerService.getLineup(gameId));
     }
 }

--- a/src/main/java/com/sports/server/team/domain/TeamPlayer.java
+++ b/src/main/java/com/sports/server/team/domain/TeamPlayer.java
@@ -1,0 +1,24 @@
+package com.sports.server.team.domain;
+
+import com.sports.server.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "team_players")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamPlayer extends BaseEntity<TeamPlayer> {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+}

--- a/src/main/resources/db/migration/V3__add-team-player.sql
+++ b/src/main/resources/db/migration/V3__add-team-player.sql
@@ -1,0 +1,11 @@
+CREATE TABLE team_players
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    team_id       BIGINT                NOT NULL,
+    name          VARCHAR(255)          NOT NULL,
+    `description` VARCHAR(255)          NULL,
+    CONSTRAINT pk_team_players PRIMARY KEY (id)
+);
+
+ALTER TABLE team_players
+    ADD CONSTRAINT FK_TEAM_PLAYERS_ON_TEAM FOREIGN KEY (team_id) REFERENCES teams (id);

--- a/src/test/java/com/sports/server/game/acceptance/GameTeamPlayerAcceptanceTest.java
+++ b/src/test/java/com/sports/server/game/acceptance/GameTeamPlayerAcceptanceTest.java
@@ -23,8 +23,8 @@ public class GameTeamPlayerAcceptanceTest extends AcceptanceTest {
     void 경기_라인업을_조회한다() {
         // given
         Long basketBallGameId = 1L;
-        Long teamAId = 1L;
-        Long teamBId = 2L;
+        Long gameTeamAId = 1L;
+        Long gameTeamBId = 2L;
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -37,15 +37,20 @@ public class GameTeamPlayerAcceptanceTest extends AcceptanceTest {
         // then
         List<GameLineupResponse> actual = toResponses(response, GameLineupResponse.class);
         GameLineupResponse teamA = actual.stream()
-                .filter(lineup -> lineup.gameTeamId().equals(teamAId))
+                .filter(lineup -> lineup.gameTeamId().equals(gameTeamAId))
                 .toList()
                 .get(0);
         GameLineupResponse teamB = actual.stream()
-                .filter(lineup -> lineup.gameTeamId().equals(teamBId))
+                .filter(lineup -> lineup.gameTeamId().equals(gameTeamBId))
                 .toList()
                 .get(0);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).hasSize(2),
+                () -> assertThat(actual)
+                        .map(GameLineupResponse::gameTeamId)
+                        .containsExactly(gameTeamAId, gameTeamBId),
+
                 () -> assertThat(teamA.teamName()).isEqualTo("팀 A"),
                 () -> assertThat(teamA.gameTeamPlayers())
                         .map(GameLineupResponse.PlayerResponse::playerName)

--- a/src/test/java/com/sports/server/game/acceptance/GameTeamPlayerAcceptanceTest.java
+++ b/src/test/java/com/sports/server/game/acceptance/GameTeamPlayerAcceptanceTest.java
@@ -1,0 +1,66 @@
+package com.sports.server.game.acceptance;
+
+import com.sports.server.game.dto.response.GameLineupResponse;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+@Sql(scripts = "/game-fixture.sql")
+public class GameTeamPlayerAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 경기_라인업을_조회한다() {
+        // given
+        Long basketBallGameId = 1L;
+        Long teamAId = 1L;
+        Long teamBId = 2L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/games/{gameId}/lineup", basketBallGameId)
+                .then().log().all()
+                .extract();
+
+        // then
+        List<GameLineupResponse> actual = toResponses(response, GameLineupResponse.class);
+        GameLineupResponse teamA = actual.stream()
+                .filter(lineup -> lineup.gameTeamId().equals(teamAId))
+                .toList()
+                .get(0);
+        GameLineupResponse teamB = actual.stream()
+                .filter(lineup -> lineup.gameTeamId().equals(teamBId))
+                .toList()
+                .get(0);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(teamA.teamName()).isEqualTo("팀 A"),
+                () -> assertThat(teamA.gameTeamPlayers())
+                        .map(GameLineupResponse.PlayerResponse::playerName)
+                        .containsExactly("선수1", "선수2", "선수3", "선수4", "선수5"),
+                () -> assertThat(teamA.gameTeamPlayers())
+                        .map(GameLineupResponse.PlayerResponse::description)
+                        .containsExactly("센터", "파워 포워드", "슈팅 가드", "포인트 가드", "스몰 포워드"),
+
+                () -> assertThat(teamB.teamName()).isEqualTo("팀 B"),
+                () -> assertThat(teamB.gameTeamPlayers())
+                        .map(GameLineupResponse.PlayerResponse::playerName)
+                        .containsExactly("선수6", "선수7", "선수8", "선수9", "선수10"),
+                () -> assertThat(teamB.gameTeamPlayers())
+                        .map(GameLineupResponse.PlayerResponse::description)
+                        .containsExactly("센터", "파워 포워드", "슈팅 가드", "포인트 가드", "스몰 포워드")
+        );
+    }
+}

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -24,19 +24,35 @@ INSERT INTO teams (name, logo_image_url, administrator_id, organization_id, leag
 VALUES ('팀 C', 'http://example.com/logo_c.png', 3, 2, 2);
 
 -- 경기의 팀
--- 농구 대전 (game_id = 1)
+-- 농구 대전 (game_id = 1) A팀 vs B팀
 INSERT INTO game_teams (game_id, team_id, cheer_count, score)
 VALUES (1, 1, 1, 1), -- 팀 A의 정보
-       (1, 2, 2, 2);
--- 팀 B의 정보
+       (1, 2, 2, 2); -- 팀 B의 정보
 
--- 롤 챔피언스 (game_id = 2)
+-- 농구 대전(game_id = 1) A팀 선수
+INSERT INTO game_team_players (id, game_team_id, name, description)
+VALUES (1, 1, '선수1', '센터'),
+       (2, 1, '선수2', '파워 포워드'),
+       (3, 1, '선수3', '슈팅 가드'),
+       (4, 1, '선수4', '포인트 가드'),
+       (5, 1, '선수5', '스몰 포워드');
+
+
+-- 농구 대전(game_id = 1) B팀 선수
+INSERT INTO game_team_players (id, game_team_id, name, description)
+VALUES (6, 2, '선수6', '센터'),
+       (7, 2, '선수7', '파워 포워드'),
+       (8, 2, '선수8', '슈팅 가드'),
+       (9, 2, '선수9', '포인트 가드'),
+       (10, 2, '선수10', '스몰 포워드');
+
+
+-- 롤 챔피언스 (game_id = 2) B팀 vs C팀
 INSERT INTO game_teams (game_id, team_id, cheer_count, score)
 VALUES (2, 2, 1, 0),
        (2, 3, 1, 0);
--- 팀 C의 정보
 
--- 루미큐브 대회 (game_id = 3)
+-- 루미큐브 대회 (game_id = 3) A팀 vs C팀
 INSERT INTO game_teams (game_id, team_id, cheer_count, score)
 VALUES (3, 1, 1, 0),
        (3, 3, 1, 0);


### PR DESCRIPTION
## 🌍 이슈 번호
closed #57 
closed #58 

## 📝 구현 내용
### 라인업 조회 기능 구현 (`games/{gameId}/lineup`)
- game_id로 전체 GameTeam의 플레이어들을 조회하는식으로 구현했어요.
- 하나의 GameTeam 당으로 조회하려다가 응원하기 조회도 한 번에 조회하고 있길래 라인업도 한 번에 불러오도록 짰습니다.
- 일단 `GameTeamPlayerService`와 `GameTeamPlayerRepository`를 만들어서 구현했습니다. 조회 로직 분리는 나중에 진행하려구요!
``` json
[
    {
        "gameTeamId": 6,
        "teamName": "...",
        "gameTeamPlayers": [
            {"playerName": "...선수", "description": "..."}, 
            {"playerName": "...선수", "description": "..."}, 
            {"playerName": "...선수", "description": "..."}
        ]
    },
    {
        "gameTeamId": 7,
        "teamName": "...",
        "gameTeamPlayers": [
            {"playerName": "...선수", "description": "..."}, 
            {"playerName": "...선수", "description": "..."}, 
            {"playerName": "...선수", "description": "..."}
        ]
    }
]
```
### TeamPlayer 추가
<img width=500 height=400 src="https://github.com/hufs-sports-live/server/assets/78652144/ee5658b0-09c2-4d88-900c-ced5f4fc9695">

``` sql 
CREATE TABLE team_players
(
    id            BIGINT AUTO_INCREMENT NOT NULL,
    team_id       BIGINT                NOT NULL,
    name          VARCHAR(255)          NOT NULL,
    `description` VARCHAR(255)          NULL,
    CONSTRAINT pk_team_players PRIMARY KEY (id)
);

ALTER TABLE team_players
    ADD CONSTRAINT FK_TEAM_PLAYERS_ON_TEAM FOREIGN KEY (team_id) REFERENCES teams (id);
```

## 🍀 확인해야 할 부분
