### PR TITLE
[FEAT] 비디오 ID 조회 API 구현 및 게임 상세 조회에 스포츠 이름 추가

### DIFF
--- a/src/main/java/com/sports/server/game/application/GameService.java
+++ b/src/main/java/com/sports/server/game/application/GameService.java
@@ -7,6 +7,7 @@ import com.sports.server.game.domain.GameTeam;
 import com.sports.server.game.domain.GameTeamRepository;
 import com.sports.server.game.dto.response.GameDetailResponse;
 import com.sports.server.game.dto.response.GameResponseDto;
+import com.sports.server.game.dto.response.VideoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,5 +32,10 @@ public class GameService {
     public List<GameResponseDto> getAllGames() {
         return gameRepository.findAll().stream().map(GameResponseDto::new)
                 .toList();
+    }
+
+    public VideoResponse getVideo(Long gameId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+        return new VideoResponse(game.getVideoId());
     }
 }

--- a/src/main/java/com/sports/server/game/dto/response/GameDetailResponse.java
+++ b/src/main/java/com/sports/server/game/dto/response/GameDetailResponse.java
@@ -11,6 +11,7 @@ public record GameDetailResponse(
         String videoId,
         String gameQuarter,
         String gameName,
+        String sportName,
         List<TeamResponse> gameTeams
 ) {
 
@@ -20,6 +21,7 @@ public record GameDetailResponse(
                 game.getVideoId(),
                 game.getGameQuarter(),
                 game.getName(),
+                game.getSport().getName(),
                 gameTeams.stream()
                         .map(TeamResponse::new)
                         .toList()

--- a/src/main/java/com/sports/server/game/dto/response/VideoResponse.java
+++ b/src/main/java/com/sports/server/game/dto/response/VideoResponse.java
@@ -1,0 +1,4 @@
+package com.sports.server.game.dto.response;
+
+public record VideoResponse(String videoId) {
+}

--- a/src/main/java/com/sports/server/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/game/presentation/GameController.java
@@ -4,10 +4,7 @@ import com.sports.server.game.application.GameService;
 import com.sports.server.game.application.GameTeamPlayerService;
 import com.sports.server.game.application.GameTeamService;
 import com.sports.server.game.dto.request.GameTeamCheerRequestDto;
-import com.sports.server.game.dto.response.GameDetailResponse;
-import com.sports.server.game.dto.response.GameLineupResponse;
-import com.sports.server.game.dto.response.GameResponseDto;
-import com.sports.server.game.dto.response.GameTeamCheerResponseDto;
+import com.sports.server.game.dto.response.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +24,11 @@ public class GameController {
     @GetMapping("/{gameId}")
     public ResponseEntity<GameDetailResponse> getGameDetail(@PathVariable final Long gameId) {
         return ResponseEntity.ok(gameService.getGameDetail(gameId));
+    }
+
+    @GetMapping("{gameId}/video")
+    public ResponseEntity<VideoResponse> getVideo(@PathVariable final Long gameId) {
+        return ResponseEntity.ok(gameService.getVideo(gameId));
     }
 
     @GetMapping

--- a/src/test/java/com/sports/server/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/game/acceptance/GameAcceptanceTest.java
@@ -38,6 +38,7 @@ class GameAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(game.gameName()).isEqualTo("농구 대전"),
                 () -> assertThat(game.gameQuarter()).isEqualTo("1st Quarter"),
                 () -> assertThat(game.videoId()).isEqualTo("abc123"),
+                () -> assertThat(game.sportName()).isEqualTo("농구"),
                 () -> assertThat(game.startTime()).isEqualTo(
                         LocalDateTime.of(2023, 11, 12, 10, 0, 0)
                 ),

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -1,5 +1,8 @@
 SET foreign_key_checks = 0;
 
+-- 스포츠
+INSERT INTO sports (id, name) VALUES (2, '농구');
+
 -- 경기
 INSERT INTO games (sport_id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter,
                    state)


### PR DESCRIPTION
## 🌍 이슈 번호
closed #66 
closed #67 

## 📝 구현 내용
- 비디오 조회 API 구현
- 게임 상세 조회에서 스포츠 이름 추가


## 🍀 확인해야 할 부분
