### PR TITLE
[FIX] 댓글 조회 순서 로직 수정 #73

### DIFF
--- a/src/main/java/com/sports/server/comment/infra/CommentDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/comment/infra/CommentDynamicRepositoryImpl.java
@@ -26,11 +26,11 @@ public class CommentDynamicRepositoryImpl implements CommentDynamicRepository {
                 .join(gameTeam).on(comment.gameTeamId.eq(gameTeam.id))
                 .where(gameTeam.game.id.eq(gameId))
                 .where(booleanBuilder
-                        .and(() -> comment.createdAt.goe(getCursorCreatedAt(cursor)))
-                        .and(() -> comment.id.gt(cursor))
+                        .and(() -> comment.createdAt.loe(getCursorCreatedAt(cursor)))
+                        .and(() -> comment.id.lt(cursor))
                         .build()
                 )
-                .orderBy(comment.createdAt.asc(), comment.id.asc())
+                .orderBy(comment.createdAt.desc(), comment.id.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/test/java/com/sports/server/comment/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/com/sports/server/comment/acceptance/CommentAcceptanceTest.java
@@ -63,17 +63,17 @@ public class CommentAcceptanceTest extends AcceptanceTest {
             List<CommentResponse> actual = toResponses(response, CommentResponse.class);
             assertAll(
                     () -> assertThat(actual).hasSize(10),
-                    () -> assertThat(actual.get(9))
+                    () -> assertThat(actual.get(0))
                             .isEqualTo(new CommentResponse(
+                                    5L,
+                                    "댓글5",
                                     1L,
-                                    "댓글1",
-                                    1L,
-                                    LocalDateTime.of(2023, 1, 1, 12, 30, 0),
+                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0),
                                     false
                             )),
                     () -> assertThat(actual)
                             .map(CommentResponse::commentId)
-                            .containsExactly(10L, 9L, 8L, 7L, 6L, 5L, 4L, 3L, 2L, 1L)
+                            .containsExactly(5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L)
             );
         }
 
@@ -81,7 +81,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         void 커서가_있으면_커서_다음부터_10개가_조회된다() {
             // given
             Long gameId = 1L;
-            Long cursor = 4L;
+            Long cursor = 12L;
 
             // when
             ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -99,7 +99,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
 
                     () -> assertThat(actual)
                             .map(CommentResponse::commentId)
-                            .containsExactly(14L, 13L, 12L, 11L, 10L, 9L, 8L, 7L, 6L, 5L)
+                            .containsExactly(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L)
             );
         }
 
@@ -125,7 +125,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
 
                     () -> assertThat(actual)
                             .map(CommentResponse::commentId)
-                            .containsExactly(5L, 4L, 3L, 2L, 1L)
+                            .containsExactly(10L, 11L, 12L, 13L, 14L)
             );
         }
 
@@ -153,7 +153,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
 
                     () -> assertThat(actual)
                             .map(CommentResponse::commentId)
-                            .containsExactly(13L, 12L, 11L, 10L, 9L)
+                            .containsExactly(3L, 4L, 5L, 6L, 7L)
             );
         }
 
@@ -161,13 +161,11 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         void 블락된_댓글은_null을_표시한다() {
             // given
             Long gameId = 1L;
-            Long cursor = 10L;
 
             // when
             ExtractableResponse<Response> response = RestAssured.given().log().all()
                     .when()
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .queryParam("cursor", cursor)
                     .get("/games/{gameId}/comments", gameId)
                     .then().log().all()
                     .extract();


### PR DESCRIPTION
## 🌍 이슈 번호
closed #73 

## 📝 구현 내용
- 댓글 정렬 기준 수정
### 지금 배포된 로직
<img width="300" height=500 alt="image" src="https://github.com/hufs-sports-live/server/assets/78652144/0a2ca06e-c134-4309-a154-754c7e8b84a9">

원래 의도는 최신순부터 조회하는 것은 맞으나 최신 -> 오래된 정렬이 아래에서 위로 올라가는 방향으로 정렬되어야 합니다. 하지만 지금 반대로 되어 있습니다. 

DB에서 정렬하고 커서페이징 하는 방향과 UI에서 보여주는 정렬 방향이 반대라 헷갈린 것 같습니다. 로직을 다음과 같이 수정했습니다.
### AS-IS
``` java
    @Override
    public List<Comment> findByGameIdOrderByStartTime(Long gameId, Long cursor, Integer size) {
        DynamicBooleanBuilder booleanBuilder = DynamicBooleanBuilder.builder();
        return queryFactory.selectFrom(comment)
                .join(gameTeam).on(comment.gameTeamId.eq(gameTeam.id))
                .where(gameTeam.game.id.eq(gameId))
                .where(booleanBuilder
                        .and(() -> comment.createdAt.goe(getCursorCreatedAt(cursor)))
                        .and(() -> comment.id.gt(cursor))
                        .build()
                )
                .orderBy(comment.createdAt.asc(), comment.id.asc())
                .limit(size)
                .fetch();
    }
```
### TO-BE
``` java
    @Override
    public List<Comment> findByGameIdOrderByStartTime(Long gameId, Long cursor, Integer size) {
        DynamicBooleanBuilder booleanBuilder = DynamicBooleanBuilder.builder();
        return queryFactory.selectFrom(comment)
                .join(gameTeam).on(comment.gameTeamId.eq(gameTeam.id))
                .where(gameTeam.game.id.eq(gameId))
                .where(booleanBuilder
                        .and(() -> comment.createdAt.loe(getCursorCreatedAt(cursor)))
                        .and(() -> comment.id.lt(cursor))
                        .build()
                )
                .orderBy(comment.createdAt.desc(), comment.id.desc())
                .limit(size)
                .fetch();
    }
```


## 🍀 확인해야 할 부분
- 로직이 잘못되었는데 테스트가 돌아갔다는 것은 테스트도 잘못 짜여있었다는 뜻입니다. 테스트도 수정했습니다.
- 커서가 없는 테스트에서는 최신 10개를 조회하기 때문에 14 ~ 5번 댓글을 조회하는 것은 맞으나 이 정렬은 반대로 되어 있어야 함
``` java
                    () -> assertThat(actual)
                            .map(CommentResponse::commentId)
                            .containsExactly(5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L)
```
