### PR TITLE
[CHORE] cors 허용 origin 외부 설정 파일로 분리

### DIFF
--- a/src/main/java/com/sports/server/common/config/WebConfig.java
+++ b/src/main/java/com/sports/server/common/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.sports.server.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -9,15 +10,15 @@ public class WebConfig implements WebMvcConfigurer {
 
     private static final String ALLOW_ALL_PATH = "/**";
     private static final String ALLOWED_METHODS = "*";
-    private static final String FRONTEND_LOCALHOST = "http://localhost:3000";
-    private static final String FRONTEND_SERVER = "https://hufscheer.site";
-    private static final String FRONTEND_SERVER_TMP = "https://hufchichi-client.vercel.app";
+
+    @Value("${cors-allow-origins}")
+    private String origins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping(ALLOW_ALL_PATH)
                 .allowedMethods(ALLOWED_METHODS)
-                .allowedOrigins(FRONTEND_LOCALHOST, FRONTEND_SERVER, FRONTEND_SERVER_TMP);
+                .allowedOrigins(origins.split(","));
     }
 
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,3 +12,4 @@ spring:
         show_sql: true
 
 report-check-origin: fake-origin.com
+cors-allow-origins: http://localhost:3000


### PR DESCRIPTION
## 🌍 이슈 번호


## 📝 구현 내용
- cors 허용 origins을 내부 하드 코딩이 아닌 application.yml로 분리
  - application-local.yml에는 localhost:3000만 허용
  - application-prod.yml에 실제 프론트 origin 설정

## 🍀 확인해야 할 부분
- origin을 외부 설정 파일로 분리함으로써 origin이 변경될 때마다 server 레포지토리를 커밋 하고 PR을 날릴 필요가 없습니다.
- be-config에서 prod.yml 파일을 수정 후 재배포만 하면 됩니다.
- be-config 레포지토리에 운영 환경 origin을 설정해두었습니다