### PR TITLE
[FIX] 경기 전체 조회 시 페이징이 올바르지 않게 되는 오류를 해결한다

### DIFF
--- a/src/main/java/com/sports/server/game/infra/GameDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/game/infra/GameDynamicRepositoryImpl.java
@@ -4,10 +4,10 @@ import static com.sports.server.game.domain.QGame.game;
 import static com.sports.server.sport.domain.QSport.sport;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameDynamicRepository;
 import com.sports.server.game.domain.GameState;
-import com.sports.server.common.dto.PageRequestDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ public class GameDynamicRepositoryImpl implements GameDynamicRepository {
                 .join(game.sport, sport).fetchJoin()
                 .where(booleanBuilder
                         .and(() -> game.startTime.goe(lastStartTime)
-                                .and(game.id.gt(pageRequestDto.cursor())))
+                                .and(game.id.ne(pageRequestDto.cursor())))
                         .and(() -> game.league.id.eq(leagueId))
                         .and(() -> game.state.eq(state))
                         .and(() -> game.sport.id.in(sportIds))

--- a/src/test/java/com/sports/server/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/game/application/GameServiceTest.java
@@ -80,6 +80,26 @@ public class GameServiceTest extends ServiceTest {
     }
 
     @Test
+    void 커서를_이용해서_조회하는_경우_경기_시작_시간이_빠른_경기가_아이디가_커서보다_큰_경기보다_먼저_반환된다() {
+
+        //given
+        int size = 5;
+        PageRequestDto pageRequestDto = new PageRequestDto(null, size);
+        GamesQueryRequestDto queryRequestDto = new GamesQueryRequestDto(1L, "SCHEDULED", List.of(1L));
+        GameResponseDto gameResponseDto = gameService.getAllGames(queryRequestDto, pageRequestDto).get(size - 1);
+        Long cursor = gameResponseDto.id();
+
+        //when
+        pageRequestDto = new PageRequestDto(cursor, size);
+        List<GameResponseDto> games = gameService.getAllGames(queryRequestDto, pageRequestDto);
+
+        // then
+        assertThat(games).extracting(GameResponseDto::id)
+                .containsExactly(7L, 5L, 8L, 9L, 10L);
+
+    }
+
+    @Test
     void 스포츠_아이디가_쿼리_스트링으로_조회되지_않는_경우_전체가_반환된다() {
 
         //given


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #80 

## 📝 구현 내용
- id 가 커서보다 크지 않은 경우에도 조회를 해야 하기에 로직을 수정한다.
   - id 가 cursor보다 작고 시작 시간이 더 빠를 가능성이 있다. 

## 🍀 확인해야 할 부분
- test 를 추가했습니다!