### PR TITLE
Fix/#84 game cursor paging

### DIFF
--- a/src/main/java/com/sports/server/game/application/GameService.java
+++ b/src/main/java/com/sports/server/game/application/GameService.java
@@ -1,24 +1,24 @@
 package com.sports.server.game.application;
 
-import static java.util.stream.Collectors.groupingBy;
-
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameDynamicRepository;
-import com.sports.server.game.domain.GameState;
 import com.sports.server.game.domain.GameTeam;
 import com.sports.server.game.domain.GameTeamRepository;
 import com.sports.server.game.dto.request.GamesQueryRequestDto;
 import com.sports.server.game.dto.response.GameDetailResponse;
 import com.sports.server.game.dto.response.GameResponseDto;
 import com.sports.server.game.dto.response.VideoResponse;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @Service
 @RequiredArgsConstructor
@@ -35,15 +35,10 @@ public class GameService {
         return new GameDetailResponse(game, teams);
     }
 
-    public List<GameResponseDto> getAllGames(
-            final GamesQueryRequestDto queryRequestDto, final PageRequestDto pageRequest) {
+    public List<GameResponseDto> getAllGames(final GamesQueryRequestDto queryRequestDto,
+                                             final PageRequestDto pageRequest) {
 
-        GameState state = GameState.from(queryRequestDto.getStateValue());
-
-        List<Game> games = gameDynamicRepository.findAllByLeagueAndStateAndSports(queryRequestDto.getLeagueId(), state,
-                queryRequestDto.getSportIds(),
-                pageRequest);
-
+        List<Game> games = gameDynamicRepository.findAllByLeagueAndStateAndSports(queryRequestDto, pageRequest);
         List<GameTeam> gameTeams = gameTeamRepository.findAllByGameIds(
                 games.stream()
                         .map(Game::getId)

--- a/src/main/java/com/sports/server/game/domain/GameDynamicRepository.java
+++ b/src/main/java/com/sports/server/game/domain/GameDynamicRepository.java
@@ -1,10 +1,11 @@
 package com.sports.server.game.domain;
 
 import com.sports.server.common.dto.PageRequestDto;
+import com.sports.server.game.dto.request.GamesQueryRequestDto;
+
 import java.util.List;
 
 public interface GameDynamicRepository {
-    List<Game> findAllByLeagueAndStateAndSports(final Long leagueId, final GameState state, final List<Long> sportIds,
-                                                final
-                                                PageRequestDto pageRequestDto);
+    List<Game> findAllByLeagueAndStateAndSports(final GamesQueryRequestDto gamesQueryRequestDto,
+                                                final PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/sports/server/game/infra/GameDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/game/infra/GameDynamicRepositoryImpl.java
@@ -1,16 +1,13 @@
 package com.sports.server.game.infra;
 
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameDynamicRepository;
-import com.sports.server.game.domain.GameState;
+import com.sports.server.game.dto.request.GamesQueryRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static com.sports.server.game.domain.QGame.game;
@@ -20,54 +17,19 @@ import static com.sports.server.sport.domain.QSport.sport;
 @RequiredArgsConstructor
 public class GameDynamicRepositoryImpl implements GameDynamicRepository {
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
     private final JPAQueryFactory jpaQueryFactory;
+    private final GamesQueryConditionMapper conditionMapper;
 
     @Override
-    public List<Game> findAllByLeagueAndStateAndSports(final Long leagueId, final GameState state,
-                                                       final List<Long> sportIds, final PageRequestDto pageRequestDto) {
-        DynamicBooleanBuilder booleanBuilder = DynamicBooleanBuilder.builder();
-        String cursorValue = getCursorValue(pageRequestDto.cursor());
-        JPAQuery<Game> gameJPAQuery = jpaQueryFactory
+    public List<Game> findAllByLeagueAndStateAndSports(final GamesQueryRequestDto gameQueryRequestDto,
+                                                       final PageRequestDto pageRequestDto) {
+        return jpaQueryFactory
                 .selectFrom(game)
                 .join(game.sport, sport).fetchJoin()
-                .where(booleanBuilder
-                        .and(() -> game.startTime.stringValue().concat(game.id.stringValue()).gt(cursorValue))
-                        .and(() -> game.league.id.eq(leagueId))
-                        .and(() -> game.state.eq(state))
-                        .and(() -> game.sport.id.in(sportIds))
-                        .build()
-                ).limit(pageRequestDto.size());
-
-        if (state.equals(GameState.FINISHED)) {
-            return gameJPAQuery
-                    .orderBy(game.startTime.stringValue().concat(game.id.stringValue()).desc())
-                    .fetch();
-        }
-
-        return gameJPAQuery
-                .orderBy(game.startTime.stringValue().concat(game.id.stringValue()).asc())
+                .where(conditionMapper.mapBooleanCondition(gameQueryRequestDto, pageRequestDto))
+                .orderBy(conditionMapper.mapOrderCondition(gameQueryRequestDto))
+                .limit(pageRequestDto.size())
                 .fetch();
-    }
-
-    private String getCursorValue(Long cursor) {
-        LocalDateTime lastStartTime = findLastStartTime(cursor);
-        if (lastStartTime == null) {
-            return null;
-        }
-        return lastStartTime.format(FORMATTER) + cursor;
-    }
-
-    private LocalDateTime findLastStartTime(final Long cursor) {
-        if (cursor == null) {
-            return null;
-        }
-        return jpaQueryFactory
-                .select(game.startTime)
-                .from(game)
-                .where(game.id.eq(cursor))
-                .fetchFirst();
     }
 
 }

--- a/src/main/java/com/sports/server/game/infra/GameDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/game/infra/GameDynamicRepositoryImpl.java
@@ -1,22 +1,26 @@
 package com.sports.server.game.infra;
 
-import static com.sports.server.game.domain.QGame.game;
-import static com.sports.server.sport.domain.QSport.sport;
-
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.game.domain.Game;
 import com.sports.server.game.domain.GameDynamicRepository;
 import com.sports.server.game.domain.GameState;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.sports.server.game.domain.QGame.game;
+import static com.sports.server.sport.domain.QSport.sport;
 
 @Repository
 @RequiredArgsConstructor
 public class GameDynamicRepositoryImpl implements GameDynamicRepository {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -24,26 +28,35 @@ public class GameDynamicRepositoryImpl implements GameDynamicRepository {
     public List<Game> findAllByLeagueAndStateAndSports(final Long leagueId, final GameState state,
                                                        final List<Long> sportIds, final PageRequestDto pageRequestDto) {
         DynamicBooleanBuilder booleanBuilder = DynamicBooleanBuilder.builder();
-
+        String cursorValue = getCursorValue(pageRequestDto.cursor());
         JPAQuery<Game> gameJPAQuery = jpaQueryFactory
                 .selectFrom(game)
                 .join(game.sport, sport).fetchJoin()
                 .where(booleanBuilder
+                        .and(() -> game.startTime.stringValue().concat(game.id.stringValue()).gt(cursorValue))
                         .and(() -> game.league.id.eq(leagueId))
                         .and(() -> game.state.eq(state))
                         .and(() -> game.sport.id.in(sportIds))
                         .build()
-                );
+                ).limit(pageRequestDto.size());
 
         if (state.equals(GameState.FINISHED)) {
             return gameJPAQuery
-                    .orderBy(game.startTime.desc(), game.id.asc())
+                    .orderBy(game.startTime.stringValue().concat(game.id.stringValue()).desc())
                     .fetch();
         }
 
         return gameJPAQuery
-                .orderBy(game.startTime.asc(), game.id.asc())
+                .orderBy(game.startTime.stringValue().concat(game.id.stringValue()).asc())
                 .fetch();
+    }
+
+    private String getCursorValue(Long cursor) {
+        LocalDateTime lastStartTime = findLastStartTime(cursor);
+        if (lastStartTime == null) {
+            return null;
+        }
+        return lastStartTime.format(FORMATTER) + cursor;
     }
 
     private LocalDateTime findLastStartTime(final Long cursor) {

--- a/src/main/java/com/sports/server/game/infra/GamesQueryConditionMapper.java
+++ b/src/main/java/com/sports/server/game/infra/GamesQueryConditionMapper.java
@@ -1,0 +1,61 @@
+package com.sports.server.game.infra;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sports.server.common.dto.PageRequestDto;
+import com.sports.server.game.domain.GameState;
+import com.sports.server.game.dto.request.GamesQueryRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.format.DateTimeFormatter;
+
+import static com.sports.server.game.domain.QGame.game;
+
+@Component
+@RequiredArgsConstructor
+public class GamesQueryConditionMapper {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public OrderSpecifier<?> mapOrderCondition(GamesQueryRequestDto request) {
+        GameState state = GameState.from(request.getStateValue());
+        if (state == GameState.FINISHED) {
+            return game.startTime.stringValue().concat(game.id.stringValue()).desc();
+        }
+        return game.startTime.stringValue().concat(game.id.stringValue()).asc();
+    }
+
+    public BooleanBuilder mapBooleanCondition(GamesQueryRequestDto gamesQueryRequestDto,
+                                              PageRequestDto pageRequestDto) {
+        GameState state = GameState.from(gamesQueryRequestDto.getStateValue());
+        String cursor = getCursorValue(pageRequestDto.cursor());
+        DynamicBooleanBuilder booleanBuilder = DynamicBooleanBuilder.builder()
+                .and(() -> game.league.id.eq(gamesQueryRequestDto.getLeagueId()))
+                .and(() -> game.state.eq(state))
+                .and(() -> game.sport.id.in(gamesQueryRequestDto.getSportIds()));
+        if (state == GameState.FINISHED) {
+            return booleanBuilder
+                    .and(() -> game.startTime.stringValue().concat(game.id.stringValue()).lt(cursor))
+                    .build();
+        }
+        return booleanBuilder
+                .and(() -> game.startTime.stringValue().concat(game.id.stringValue()).gt(cursor))
+                .build();
+    }
+
+    private String getCursorValue(Long cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return jpaQueryFactory
+                .select(game.startTime)
+                .from(game)
+                .where(game.id.eq(cursor))
+                .fetchFirst()
+                .format(FORMATTER) + cursor;
+    }
+}

--- a/src/test/java/com/sports/server/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/game/acceptance/GameAcceptanceTest.java
@@ -1,20 +1,20 @@
 package com.sports.server.game.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.sports.server.game.dto.response.GameDetailResponse;
 import com.sports.server.game.dto.response.GameResponseDto;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Sql(scripts = "/game-fixture.sql")
 class GameAcceptanceTest extends AcceptanceTest {
@@ -63,7 +63,6 @@ class GameAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    @Disabled
     @Test
     void 리그의_경기를_전체_조회한다() {
 

--- a/src/test/java/com/sports/server/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/game/application/GameServiceTest.java
@@ -188,7 +188,7 @@ public class GameServiceTest extends ServiceTest {
 
         //then
         assertThat(games).extracting(GameResponseDto::id)
-                .containsExactly(14L, 15L);
+                .containsExactly(15L, 14L);
 
     }
 

--- a/src/test/java/com/sports/server/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/game/application/GameServiceTest.java
@@ -1,24 +1,24 @@
 package com.sports.server.game.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.game.dto.request.GamesQueryRequestDto;
 import com.sports.server.game.dto.response.GameResponseDto;
 import com.sports.server.game.dto.response.GameResponseDto.TeamResponse;
 import com.sports.server.support.ServiceTest;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Sql(scripts = "/game-fixture.sql")
 public class GameServiceTest extends ServiceTest {
@@ -44,7 +44,7 @@ public class GameServiceTest extends ServiceTest {
 
     }
 
-    @Disabled
+    
     @Test
     void 날짜순으로_경기들이_반환된다() {
 
@@ -63,7 +63,7 @@ public class GameServiceTest extends ServiceTest {
                 .containsExactly(1L, 2L, 3L, 4L, 6L);
     }
 
-    @Disabled
+    
     @Test
     void 시작_날짜가_같은_경우_pk순으로_경기가_반환된다() {
 
@@ -82,7 +82,7 @@ public class GameServiceTest extends ServiceTest {
                 .containsExactly(3L, 4L, 6L, 7L, 5L);
     }
 
-    @Disabled
+    
     @Test
     void 커서를_이용해서_조회하는_경우_경기_시작_시간이_빠른_경기가_아이디가_커서보다_큰_경기보다_먼저_반환된다() {
 
@@ -103,7 +103,7 @@ public class GameServiceTest extends ServiceTest {
 
     }
 
-    @Disabled
+    
     @Test
     void 스포츠_아이디가_쿼리_스트링으로_조회되지_않는_경우_전체가_반환된다() {
 
@@ -119,7 +119,7 @@ public class GameServiceTest extends ServiceTest {
         );
     }
 
-    @Disabled
+    
     @Test
     void 리그_아이디가_쿼리_스트링으로_조회되지_않는_경우_전체가_반환된다() {
 
@@ -136,7 +136,7 @@ public class GameServiceTest extends ServiceTest {
 
     }
 
-    @Disabled
+    
     @Test
     void 스포츠_아이디가_여러개인_경우_스포츠에_해당하는_전체_경기가_반환된다() {
 
@@ -176,7 +176,7 @@ public class GameServiceTest extends ServiceTest {
 
     }
 
-    @Disabled
+    
     @Test
     void 조회한_경기상태에_해당하는_경기만_반환한다() {
 
@@ -220,7 +220,7 @@ public class GameServiceTest extends ServiceTest {
     @DisplayName("경기들을 페이징을 이용해서 조회할 때")
     class PagingTest {
 
-        @Disabled
+        
         @Test
         void 세개만_조회한다() {
 
@@ -239,7 +239,7 @@ public class GameServiceTest extends ServiceTest {
 
         }
 
-        @Disabled
+        
         @Test
         void 기본적으로_10개를_조회한다() {
 

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -1,4 +1,5 @@
-SET foreign_key_checks = 0;
+SET
+foreign_key_checks = 0;
 
 -- 경기
 INSERT INTO games (id, sport_id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at,
@@ -28,7 +29,26 @@ VALUES (1, 1, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-1
        (14, 2, 1, 1, '열네번쨰로 빠른 경기', '2023-11-12T20:10:00', 'abc123', '2023-11-12T14:15:00', '1st Quarter',
         'FINISHED'),
        (15, 2, 1, 1, '열다섯번째로 빠른 경기', '2023-11-12T21:10:00', 'abc123', '2023-11-12T14:15:00', '1st Quarter',
+        'FINISHED'),
+
+       (19, 1, 1, 1, '12월 중 첫번째 빠른 경기', '2023-12-03T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'SCHEDULED'),
+       (18, 1, 1, 1, '12월 중 두번째 빠른 경기', '2023-12-04T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'SCHEDULED'),
+       (16, 1, 1, 1, '12월 중 세번째 빠른 경기', '2023-12-05T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'SCHEDULED'),
+       (17, 1, 1, 1, '12월 중 네번째 빠른 경기', '2023-12-05T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'SCHEDULED'),
+
+       (23, 1, 1, 1, '12월 중 첫번째 빠른 경기', '2023-12-03T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'FINISHED'),
+       (22, 1, 1, 1, '12월 중 두번째 빠른 경기', '2023-12-04T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'FINISHED'),
+       (20, 1, 1, 1, '12월 중 세번째 빠른 경기', '2023-12-05T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
+        'FINISHED'),
+       (21, 1, 1, 1, '12월 중 네번째 빠른 경기', '2023-12-05T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter',
         'FINISHED');
+
 
 -- 팀
 INSERT
@@ -115,4 +135,5 @@ INSERT
 INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted)
 VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00', false);
 
-SET foreign_key_checks = 1;
+SET
+foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
closed #84 

## 📝 구현 내용
- start_time + id를 합친 문자열로 정렬 및 커서 역할을 하도록하여 무한 커서페이징이 되는 문제를 방지
- `GamesQueryConditionMapper`클래스로 쿼리 만드는 책임을 위임

## 🍀 확인해야 할 부분
- 이렇게 하게 되면 쿼리가 아래처럼 나가게 됩니다.
``` sql
... WHERE CONCAT(CAST(start_time as char), CAST(id as char)) < ? ... ORDER BY CONCAT(CAST(start_time as char), CAST(id as char)) asc ...;
```

이 방식의 한 가지 문제점이 인덱스를 걸지 못한다는 것입니다. 만약 조회해야 하는 게임이 많아지면 정렬하거나 커서를 찾는데 전체 데이터를 뒤져야 하기에 원래는 `start_time`에 인덱스를 걸려고 했었습니다.

`CONCAT(CAST(start_time as char), CAST(id as char))`이라는 함수에도 함수 기반 인덱스를 걸 수 있어 나중에 그러려고 했는데 auto_increment되는 pk로는 함수 기반 인덱스를 만들 수 없다고 하네요.
``` sql
Functional index 'ix_start_time_id' cannot refer to an auto-increment column.
```

게임을 league를 반드시 조건에 포함하여 조회하도록 하면 league_id에 걸린 외래키 인덱스를 사용하기에 그나마 괜찮을 것 같긴 합니다만 전체 게임을 조회할 때 필히 느린 쿼리가 될거에요. 

이를 훗날 데이터가 많아졌을 때 성능적으로 개선하려면 정렬 및 커서 역할을 하는 칼럼을 주가하거나 (날짜와 조합하여 id 대신 사용하도록 + 함수 기반 인덱스 추가) league를 반드시 조건에 포함시켜 조회하도록 하거나 (한 리그에 게임이 많지 않다는 가정 하에) 해야할 것 같아요.